### PR TITLE
Correct setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import codecs
+import io
 
 from setuptools import setup, find_packages
 
@@ -13,7 +14,7 @@ long_description = codecs.open('README.md', "r", "utf-8").read()
 def is_pkg(line):
     return line and not line.startswith(('--', 'git', '#'))
 
-with open('requirements.txt', encoding='utf-8') as reqs:
+with io.open('requirements.txt', encoding='utf-8') as reqs:
     install_requires = [l for l in reqs.read().split('\n') if is_pkg(l)]
 
 setup(


### PR DESCRIPTION
On Debian Jessie with pip install :

Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-o_ERWm-build/setup.py", line 16, in <module>
        with open('requirements.txt', encoding='utf-8') as reqs:
    TypeError: 'encoding' is an invalid keyword argument for this function