### PR TITLE
Change wrong link to RDTD documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ It uses [django-leaflet-storage](https://github.com/umap-project/django-leaflet-
 
 ## Installation and configuration
 
-See [developper documentation](https://umap-project.readthedocs.org/install/).
+See [developper documentation](https://umap-project.readthedocs.io/en/latest/install/).


### PR DESCRIPTION
The previous link was redirecting to an inexisting content > changed.