### PR TITLE
fix feedback anchor link to wiki (httpS)

### DIFF
--- a/umap/settings/base.py
+++ b/umap/settings/base.py
@@ -166,7 +166,7 @@ UMAP_MAPS_PER_PAGE = 5
 UMAP_MAPS_PER_PAGE_OWNER = 10
 MAP_SHORT_URL_NAME = "umap_short_url"
 UMAP_USE_UNACCENT = False
-UMAP_FEEDBACK_LINK = "http://wiki.openstreetmap.org/wiki/UMap#Feedback_and_help"  # noqa
+UMAP_FEEDBACK_LINK = "https://wiki.openstreetmap.org/wiki/UMap#Feedback_and_help"  # noqa
 USER_MAPS_URL = 'user_maps'
 
 # =============================================================================


### PR DESCRIPTION
Swap this wiki link to httpS

The wiki is now on httpS and sadly the httpS redirect causes #anchor links to be lost