### PR TITLE
bump social-auth to use https:// for osm.org oauth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ Pillow==4.1.0
 psycopg2==2.7.1
 requests==2.13.0
 social-auth-app-django==1.1.0
-social-auth-core==1.2.0
+social-auth-core==1.7.0


### PR DESCRIPTION
openstreetmap.org switched to https://
login with umap does not work anymore with old
social-auth version. The new version now has the
https:// urls.