### PR TITLE
Fix original English translation strings

### DIFF
--- a/umap/management/commands/import_pictograms.py
+++ b/umap/management/commands/import_pictograms.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
         parser.add_argument('--attribution', required=True,
                             help='Attribution of the imported pictograms')
         parser.add_argument('--suffix',
-                            help='Optionnal suffix to add to each name')
+                            help='Optional suffix to add to each name')
         parser.add_argument('--force', action='store_true',
                             help='Update picto if it already exists.')
 

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -709,7 +709,7 @@ L.U.Map.include({
         layerInput.name = 'datalayer';
         urlInput.type = 'text';
         urlInput.placeholder = L._('Provide an URL here');
-        rawInput.placeholder = L._('Paste here your data');
+        rawInput.placeholder = L._('Paste your data here');
         clearLabel.textContent = L._('Replace layer content');
         var clearFlag = L.DomUtil.create('input', '', clearLabel);
         clearFlag.type = 'checkbox';

--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -796,8 +796,8 @@ L.U.DataLayer = L.Evented.extend({
         var remoteDataFields = [
             ['options.remoteData.url', {handler: 'Url', label: L._('Url'), helpEntries: 'formatURL'}],
             ['options.remoteData.format', {handler: 'DataFormat', label: L._('Format')}],
-            ['options.remoteData.from', {label: L._('From zoom'), helpText: L._('Optionnal.')}],
-            ['options.remoteData.to', {label: L._('To zoom'), helpText: L._('Optionnal.')}],
+            ['options.remoteData.from', {label: L._('From zoom'), helpText: L._('Optional.')}],
+            ['options.remoteData.to', {label: L._('To zoom'), helpText: L._('Optional.')}],
             ['options.remoteData.dynamic', {handler: 'Switch', label: L._('Dynamic'), helpEntries: 'dynamicRemoteData'}],
             ['options.remoteData.licence', {label: L._('Licence'), helpText: L._('Please be sure the licence is compliant with your use.')}]
         ];

--- a/umap/static/umap/js/umap.permissions.js
+++ b/umap/static/umap/js/umap.permissions.js
@@ -48,7 +48,7 @@ L.U.MapPermissions = L.Class.extend({
     },
 
     edit: function () {
-        if (!this.map.options.umap_id) return this.map.ui.alert({content: L._('Please save the map before'), level: 'info'});
+        if (!this.map.options.umap_id) return this.map.ui.alert({content: L._('Please save the map first'), level: 'info'});
         var container = L.DomUtil.create('div', 'permissions-panel'),
             fields = [],
             title = L.DomUtil.create('h4', '', container);

--- a/umap/templates/umap/about_summary.html
+++ b/umap/templates/umap/about_summary.html
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col quarter mwide">
       <img class="colophon" src="{{ STATIC_URL }}umap/img/osm.svg" />
-      <p>{% blocktrans with osm_url="http://osm.org" %}uMap let you create maps with <a href="{{ osm_url }}" />OpenStreetMap</a> layers in a minute and embed them in your site.{% endblocktrans %}</p>
+      <p>{% blocktrans with osm_url="http://osm.org" %}uMap lets you create maps with <a href="{{ osm_url }}" />OpenStreetMap</a> layers in a minute and embed them in your site.{% endblocktrans %}</p>
     </div>
     <div class="col umap-features-list half mwide">
       <img class="colophon" src="{{ STATIC_URL }}umap/img/edit.svg" />


### PR DESCRIPTION
It seems mistakes in the original English (en) translation strings are
not fixed in the website despite them being correct for en_US in
Transifex for several years. My guess is that they are the default for
en, so unless you somehow manage to explicitly select en_US (which does
not seem possible), you are stuck with the incorrect English.