### PR TITLE
Remove protocol from iframe src url

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -1033,7 +1033,7 @@ L.U.IframeExporter = L.Evented.extend({
 
     initialize: function (map) {
         this.map = map;
-        this.baseUrl = window.location.protocol + '//' + window.location.host + window.location.pathname;
+        this.baseUrl = '//' + window.location.host + window.location.pathname;
         // Use map default, not generic default
         this.queryString.onLoadPanel = this.map.options.onLoadPanel;
     },


### PR DESCRIPTION
I tested locally, the iframe and the See full screen are working great.

Here is a sample of generated code fro iframe

> <iframe width="100%" height="300px" frameborder="0" allowfullscreen src="//localhost:8000/en/map/test-cyclosm_1?scaleControl=false&miniMap=false&scrollWheelZoom=false&zoomControl=true&allowEdit=false&moreControl=true&searchControl=null&tilelayersControl=null&embedControl=null&datalayersControl=true&onLoadPanel=undefined&captionBar=false"></iframe><p>

And for the full screen link: 

> `<a href="//localhost:8000/en/map/test-cyclosm_1">See full screen</a></p>`

Note that in source code `baseUrl` is only used for iframe src url, nothing else.

BTW, this PR is related to the proposal i made in #662