### PR TITLE
Update username with value from OAuth provider

### DIFF
--- a/umap/settings/base.py
+++ b/umap/settings/base.py
@@ -213,5 +213,5 @@ SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.user.create_user',
     'social_core.pipeline.social_auth.associate_user',
     'social_core.pipeline.social_auth.load_extra_data',
-    'social_core.pipeline.user.user_details'
+    'umap.utils.user_details'
 )

--- a/umap/settings/base.py
+++ b/umap/settings/base.py
@@ -213,5 +213,5 @@ SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.user.create_user',
     'social_core.pipeline.social_auth.associate_user',
     'social_core.pipeline.social_auth.load_extra_data',
-    'umap.utils.user_details'
+    'umap.utils.oauth_user_details'
 )

--- a/umap/utils.py
+++ b/umap/utils.py
@@ -110,8 +110,12 @@ def gzip_file(from_path, to_path):
         with gzip.open(to_path, 'wb') as f_out:
             f_out.writelines(f_in)
 
-def user_details(strategy, details, user=None, *args, **kwargs):
-    """Update user details using data from provider."""
+def oauth_user_details(strategy, details, user=None, *args, **kwargs):
+    """
+    This method is a pipeline stage only to be used with social_auth
+    Note this is a workaround that can break if social_auth is updated
+    Update user details using data from provider.
+    """
     if not user:
         return
 

--- a/umap/utils.py
+++ b/umap/utils.py
@@ -109,3 +109,33 @@ def gzip_file(from_path, to_path):
     with open(from_path, 'rb') as f_in:
         with gzip.open(to_path, 'wb') as f_out:
             f_out.writelines(f_in)
+
+def user_details(strategy, details, user=None, *args, **kwargs):
+    """Update user details using data from provider."""
+    if not user:
+        return
+
+    changed = False  # flag to track changes
+    # uMap fix: remove 'username' from protected fields
+    protected = ('id', 'pk', 'email') + \
+                tuple(strategy.setting('PROTECTED_USER_FIELDS', []))
+
+    # Update user model attributes with the new data sent by the current
+    # provider. Update on some attributes is disabled by default, for
+    # example username and id fields. It's also possible to disable update
+    # on fields defined in SOCIAL_AUTH_PROTECTED_USER_FIELDS.
+    for name, value in details.items():
+        if value is None or not hasattr(user, name) or name in protected:
+            continue
+
+        # Check https://github.com/omab/python-social-auth/issues/671
+        current_value = getattr(user, name, None)
+        # uMap fix: update field when value has changed
+        if current_value == value:
+            continue
+
+        changed = True
+        setattr(user, name, value)
+
+    if changed:
+        strategy.storage.user.changed(user)


### PR DESCRIPTION
Here is a fix for the issue #302 (changing username in OSM do not sync in uMap).

I tracked this problem deep down the following issues:

-  python-social-auth/social-core#263
-  python-social-auth/social-core#348

This issue is related to the fact that in "Python Social Auth - Core", the field "username" is protected and can not be updated. So if you change your username in OSM, GitHub, BitBucket or Twitter, it will never be synced in uMap. :disappointed:

The best solution is a fix in "Python Social Auth - Core", we should allow developers to ignore those "default protected fields", i will probably make a PR to social-core.

So i made a workaround in uMap to fix this issue and it is working nicely. To do so, iI defined my own [pipeline](https://python-social-auth.readthedocs.io/en/latest/pipeline.html) and used it instead of the default pipeline.

This PR will fix following issues: #491, #302