### PR TITLE
Allow variables in tooltips

### DIFF
--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -157,6 +157,9 @@ L.U.FeatureMixin = {
     getDisplayName: function (fallback) {
         if (fallback === undefined) fallback = this.datalayer.options.name;
         var key = this.getOption('labelKey') || 'name';
+        // Variables mode.
+        if (key.indexOf("{") != -1) return L.Util.greedyTemplate(key, this.extendedProperties());
+        // Simple mode.
         return this.properties[key] || this.properties.title || fallback;
     },
 

--- a/umap/static/umap/test/Feature.js
+++ b/umap/static/umap/test/Feature.js
@@ -179,6 +179,17 @@ describe('L.U.FeatureMixin', function () {
 
     });
 
+    describe('#tooltip', function () {
+
+        it('should have a tooltip when active and allow variables', function () {
+            this.map.options.showLabel = true;
+            this.map.options.labelKey = "Foo {name}";
+            this.datalayer.redraw();
+            assert.equal(qs('.leaflet-tooltip-pane .leaflet-tooltip').textContent, "Foo name poly");
+        });
+
+    });
+
     describe('#properties()', function () {
 
         it('should rename property', function () {


### PR DESCRIPTION
fix #737

This allows to use variables in the `labelKey` field, eg. `Foo {var1} ({var2})`, and it will be used wherever we display a "feature label".