### PR TITLE
Update requirements.txt for Pillow with python3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==2.2.11
 django-agnocomplete==1.0.0
 django-compressor==2.4
-Pillow==6.2.2
+Pillow==8.0.1
 psycopg2==2.8.4
 requests==2.23.0
 social-auth-core==3.3.2


### PR DESCRIPTION
Bump Pillow version to 8.0.1
Pillow version >= 8.0 is mandatory for python3.9 (default python version on current Ubuntu LTS 20.04