### PR TITLE
Fix and enhance property fallbacks

### DIFF
--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -134,8 +134,11 @@ L.Util.greedyTemplate = function (str, data, ignore) {
         return value;
     }
 
-    return str.replace(/\{ *([\w_\:\."\|]+) *\}/g, function (str, key) {
+    return str.replace(/\{ *([\w_\:\.\|]+)(?:\|("[^"]*"))? *\}/g, function (str, key, staticFallback) {
         var vars = key.split('|'), value, path;
+        if (staticFallback !== undefined) {
+            vars.push(staticFallback);
+        }
         for (var i = 0; i < vars.length; i++) {
             path = vars[i];
             if (path.startsWith('"') && path.endsWith('"')) value = path.substring(1, path.length -1); // static default value.

--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -140,6 +140,7 @@ L.Util.greedyTemplate = function (str, data, ignore) {
             path = vars[i];
             if (path.startsWith('"') && path.endsWith('"')) value = path.substring(1, path.length -1); // static default value.
             else value = getValue(data, path.split('.'));
+            if (value !== undefined) break;
         }
         if (value === undefined) {
             if (ignore) value = str;

--- a/umap/static/umap/test/Util.js
+++ b/umap/static/umap/test/Util.js
@@ -178,6 +178,13 @@ describe('L.Util', function () {
             assert.equal(L.Util.greedyTemplate('A phrase with a {fr.var.bar|try.again|"default"}.', {}), 'A phrase with a default.');
         });
 
+        it('should use the first defined value', function () {
+            assert.equal(L.Util.greedyTemplate('A phrase with a {fr.var.bar|try.again|"default"}.', {try: { again: 'please'}}), 'A phrase with a please.');
+        });
+
+        it('should use the first defined value', function () {
+            assert.equal(L.Util.greedyTemplate('A phrase with a {fr.var.bar|try.again|"default"}.', {try: { again: 'again'}, fr: {var: {bar: 'value'}}}), 'A phrase with a value.');
+        });
     });
 
     describe('#TextColorFromBackgroundColor', function () {

--- a/umap/static/umap/test/Util.js
+++ b/umap/static/umap/test/Util.js
@@ -185,6 +185,26 @@ describe('L.Util', function () {
         it('should use the first defined value', function () {
             assert.equal(L.Util.greedyTemplate('A phrase with a {fr.var.bar|try.again|"default"}.', {try: { again: 'again'}, fr: {var: {bar: 'value'}}}), 'A phrase with a value.');
         });
+
+        it('should support the first example from #820 when translated to final syntax', function () {
+            assert.equal(L.Util.greedyTemplate('# {name} ({ele|"-"} m ü. M.)', {name: 'Portalet'}), '# Portalet (- m ü. M.)');
+        });
+
+        it('should support the first example from #820 when translated to final syntax when no fallback required', function () {
+            assert.equal(L.Util.greedyTemplate('# {name} ({ele|"-"} m ü. M.)', {name: 'Portalet', ele: 3344}), '# Portalet (3344 m ü. M.)');
+        });
+
+        it('should support white space in fallback', function () {
+            assert.equal(L.Util.greedyTemplate('A phrase with {var|"white space in the fallback."}', {}), 'A phrase with white space in the fallback.');
+        });
+
+        it('should support empty string as fallback', function () {
+            assert.equal(L.Util.greedyTemplate('A phrase with empty string ("{var|""}") in the fallback.', {}), 'A phrase with empty string ("") in the fallback.');
+        });
+
+        it('should support e.g. links as fallback', function () {
+            assert.equal(L.Util.greedyTemplate('A phrase with {var|"[[https://osm.org|link]]"} as fallback.', {}), 'A phrase with [[https://osm.org|link]] as fallback.');
+        });
     });
 
     describe('#TextColorFromBackgroundColor', function () {


### PR DESCRIPTION
The new 'coalesce feature' from issue #820 was mentioned at our latest (virtual) [Swiss/Zurich OSM meeting](https://wiki.openstreetmap.org/wiki/DE:Switzerland:Z%C3%BCrich/OSM-Treffen#124._OSM-Stammtisch_Fr._11._Dezember_2020). However, it did not seem to work at all on [our](https://umap.osm.ch/) uMap instance. Although this turned out to have been a simple deployment issue, when looking at the code, I also noticed a small implementation error which made it always use the last fallback if there were any, even if the first property lookup or any of the previous fallbacks returned a defined value. I also noticed that the characters that could be used in the static fallback were quite limited such that the original example from issue #820 would not have worked (even when adapted to the final syntax). The changes in this pull request should fix these two issues.

I didn't look into fixing the issue with failing fallback if the property is called `description` though - I assume this is caused by the line below `// Resolve properties inside description` in the `renderBody` function of `L.U.PopupTemplate.Default` where its value gets set to the empty string even if it didn't exist in the original properties, so there will always be a defined `description` property when evaluating the template in the next but one line. Might be worth fixing if somebody gets around to it.