### PR TITLE
redirect users back to TLS version of umap after 3rd party auth.

### DIFF
--- a/umap/settings/local.py.sample
+++ b/umap/settings/local.py.sample
@@ -58,6 +58,7 @@ SOCIAL_AUTH_OPENSTREETMAP_SECRET = 'xxx'
 MIDDLEWARE += (
     'social_django.middleware.SocialAuthExceptionMiddleware',
 )
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
 SOCIAL_AUTH_RAISE_EXCEPTIONS = False
 SOCIAL_AUTH_BACKEND_ERROR_URL = "/"
 


### PR DESCRIPTION
setting "SOCIAL_AUTH_REDIRECT_IS_HTTPS = True" per https://python-social-auth.readthedocs.io/en/latest/configuration/settings.html#processing-redirects-and-urlopen with a view of resolving https://github.com/umap-project/umap/issues/846