### PR TITLE
CSS: Fix cut of text in table of popup content

### DIFF
--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -1297,6 +1297,7 @@ a.add-datalayer:hover,
 .umap-popup-container {
     flex-grow: 1;
     padding: 0 10px;
+    word-break: break-word;
 }
 .leaflet-popup-content h3 {
     margin-bottom: 0;

--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -1289,6 +1289,7 @@ a.add-datalayer:hover,
 }
 .umap-popup-content iframe {
     min-width: 310px;
+    max-width: 100%;
 }
 .umap-popup-content th,
 .umap-popup-content td {

--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -1283,14 +1283,16 @@ a.add-datalayer:hover,
 .umap-popup-content {
     max-height: 500px;
     flex-grow: 1;
-    overflow-y: auto;
-    overflow-x: hidden;
     margin-bottom: 4px;
     display: flex;
     flex-direction: column;
 }
 .umap-popup-content iframe {
     min-width: 310px;
+}
+.umap-popup-content th,
+.umap-popup-content td {
+    word-break: break-word;
 }
 .umap-popup-container {
     flex-grow: 1;


### PR DESCRIPTION
Whenever the key or value is too long, the table was pushed being wider than the given container. And the overflow rules cut off the content of the table.

Fixes
- Remove overflow rules (reset to defaults, which is `auto`), which makes a scroll bar show up if content is too wide
- Let long text break in lines instead of pushing the table (which in turn prevents the scroll bar from showing up)

Test case: https://umap.openstreetmap.de/de/map/version-2-zes-datenprufung-oberflachen_20496#12/52.3474/13.6080

| before | after |
|---|---|
|  <img width="426" alt="Bildschirmfoto 2021-12-22 um 14 43 12" src="https://user-images.githubusercontent.com/111561/147102523-7e45a0c5-78ca-46b5-a6c2-52e616eae8cf.png"> |  <img width="594" alt="Bildschirmfoto 2021-12-22 um 14 43 18" src="https://user-images.githubusercontent.com/111561/147102553-46a2e6b4-203d-4aa4-96ec-2d0f05e712cf.png"> |

