### PR TITLE
🐛 — Allow to use SHA1-signed anonymous edit URL

### DIFF
--- a/umap/views.py
+++ b/umap/views.py
@@ -657,17 +657,21 @@ class MapAnonymousEditUrl(RedirectView):
         try:
             pk = signer.unsign(self.kwargs["signature"])
         except BadSignature:
-            return HttpResponseForbidden()
-        else:
-            map_inst = get_object_or_404(Map, pk=pk)
-            url = map_inst.get_absolute_url()
-            response = HttpResponseRedirect(url)
-            if not map_inst.owner:
-                key, value = map_inst.signed_cookie_elements
-                response.set_signed_cookie(
-                    key=key, value=value, max_age=ANONYMOUS_COOKIE_MAX_AGE
-                )
-            return response
+            signer = Signer(algorithm='sha1')
+            try:
+                pk = signer.unsign(self.kwargs["signature"])
+            except BadSignature:
+                return HttpResponseForbidden()
+
+        map_inst = get_object_or_404(Map, pk=pk)
+        url = map_inst.get_absolute_url()
+        response = HttpResponseRedirect(url)
+        if not map_inst.owner:
+            key, value = map_inst.signed_cookie_elements
+            response.set_signed_cookie(
+                key=key, value=value, max_age=ANONYMOUS_COOKIE_MAX_AGE
+            )
+        return response
 
 
 # ############## #


### PR DESCRIPTION
The default django.core.signing Signer uses SHA256 algorithm since Django 3. Umap used Django 2 in the paste, so people had SHA1 signed anonymous edit URLs, which became unusable when umap switch to Django 3. This commit makes them usable again (the new SHA256-signed anonymous edit URLs still works, obviously).