### PR TITLE
Make visible titles from the control bar on hover

### DIFF
--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -117,6 +117,17 @@ a.umap-control-text {
 .leaflet-control-edit-enable a:hover {
     background-color: #4d5759;
 }
+.leaflet-control-toolbar .leaflet-toolbar-icon.dark:hover::before,
+.leaflet-control-edit-enable a:hover::before {
+    content: attr(title);
+    background: #4d5759;
+    position: relative;
+    display: inline-block;
+    margin-left: -222px;
+    min-width: 170px;
+    padding: .4rem;
+    color: white;
+}
 .umap-permanent-credits-container {
     max-width: 20rem;
     margin-left: 5px!important;


### PR DESCRIPTION
This is an attempt at making labels of buttons from the control bar more explicit when hovering (it reuses the `title` attribute of these links).

![umap-titles-hover](https://user-images.githubusercontent.com/3556/235510622-00736971-8894-45a7-aeaa-d56000f29172.gif)
