### PR TITLE
Lazy load tile layers thumbnails

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -975,6 +975,7 @@ L.U.TileLayerControl = L.Control.extend({
       img = L.DomUtil.create('img', '', el),
       name = L.DomUtil.create('div', '', el)
     img.src = L.Util.template(tilelayer.options.url_template, this.map.demoTileInfos)
+    img.loading = 'lazy'
     name.textContent = tilelayer.options.name
     L.DomEvent.on(
       el,


### PR DESCRIPTION
The list can be pretty big (like on OSMfr):
<img width="514" alt="Capture d’écran, le 2023-05-18 à 12 55 49" src="https://github.com/umap-project/umap/assets/3556/3d61abbf-0769-4918-af1c-701605a9723e">

