### PR TITLE
Display the steps for inputs of type range

### DIFF
--- a/umap/static/umap/base.css
+++ b/umap/static/umap/base.css
@@ -512,6 +512,13 @@ i.info {
 .umap-browse-datalayers {
     padding: 0 10px;
 }
+.umap-field-datalist {
+    display: flex;
+    justify-content: space-between;
+    font-size: 9px;
+    margin-top: -8px;
+    padding: 0 5px;
+}
 .umap-form-iconfield {
     position: relative;
     overflow: hidden;

--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -801,6 +801,23 @@ L.FormBuilder.Range = L.FormBuilder.Input.extend({
   value: function () {
     return L.DomUtil.hasClass(this.wrapper, 'undefined') ? undefined : this.input.value
   },
+
+  buildHelpText: function () {
+    var datalist = L.DomUtil.create(
+      'datalist',
+      'umap-field-datalist',
+      this.getHelpTextParent()
+    )
+    datalist.id = `range-${this.options.label}`
+    this.input.setAttribute('list', datalist.id)
+    var options = ''
+    for (var i = this.options.min; i <= this.options.max; i += this.options.step) {
+      options += `<option value="${i.toPrecision(2)}" label="${i.toPrecision(
+        2
+      )}"></option>`
+    }
+    datalist.innerHTML = options
+  },
 })
 
 L.FormBuilder.ManageOwner = L.FormBuilder.Element.extend({


### PR DESCRIPTION
Fix #877

This is not as slick as I hoped for but better than nothing 🤷 

Firefox:
<img width="359" alt="Capture d’écran, le 2023-05-18 à 14 15 12" src="https://github.com/umap-project/umap/assets/3556/6df40804-fb8a-4968-a7f2-7b46c8a283cc">

Chromium:
<img width="362" alt="Capture d’écran, le 2023-05-18 à 14 19 40" src="https://github.com/umap-project/umap/assets/3556/8c9bea8a-e706-4b61-92ec-65967158cf8e">

