### PR TITLE
📝 — Fix X-Accel-Redirect doc

### DIFF
--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -328,8 +328,6 @@ And then add this new location in your nginx config (before the `/` location):
 
     location /internal/ {
         internal;
-        gzip_vary on;
-        gzip_static on;
         alias /path/to/umap/var/data/;
     }
 


### PR DESCRIPTION
Since 1.2.5, you don’t need `gzip` instructions for `location /internal` anymore. In fact, it breaks the calls for datalayers!

I think it comes from 8294f896c4ccd6efff642e6f615f07ec19e49ed4, but I can’t be sure.

Anyway, removing `gzip` instructions for `location /internal` fixes our instance.