### PR TITLE
Remove `DIRS` from `settings.TEMPLATES`

### DIFF
--- a/umap/settings/base.py
+++ b/umap/settings/base.py
@@ -169,9 +169,6 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'APP_DIRS': True,
-        'DIRS': [
-            os.path.join(PROJECT_DIR, 'templates'),
-        ],
         'OPTIONS': {
             'context_processors': (
                 'django.contrib.auth.context_processors.auth',


### PR DESCRIPTION
It’s more convenient to let the sub-themes declare their own templates (especially with `'APP_DIRS': True`).