### PR TITLE
Ability to resize the list of layers displayed on the map

### DIFF
--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -587,8 +587,9 @@ ul.photon-autocomplete {
     border-radius: 2px;
 }
 .leaflet-control-browse .umap-browse-datalayers {
-    max-height: 10em;
+    height: max-content;
     overflow-y: auto;
+    resize: vertical;
 }
 .search-result-tools i,
 .leaflet-inplace-toolbar a,


### PR DESCRIPTION
This is a proposed change to resize the list of layers to fit the content of the list by default and give the ability to resize the window.

I felt that I was constrained by the fixed size that wasn't displaying enough layers to be comfortable to use.

![layer_resize](https://github.com/umap-project/umap/assets/59520411/e96c8516-c404-4c96-bdc0-1bd85ba7a342)
