### PR TITLE
Show messages also in the content part

### DIFF
--- a/umap/static/umap/content.css
+++ b/umap/static/umap/content.css
@@ -259,6 +259,27 @@ ul.umap-autocomplete {
     cursor: pointer;
 }
 
+/* **************************** */
+/*           Messages           */
+/* **************************** */
+.messages li {
+    border-radius: 1px;
+    color: white;
+    margin-bottom: 20px;
+    padding: 20px;
+    text-align: center;
+    width: 100%;
+    background-color: #444;
+    font-weight: bold;
+}
+
+.messages .success {
+    background-color: #16a085;
+}
+
+.messages .error {
+    background-color: #c60f13;
+}
 
 
 /* **************************** */

--- a/umap/templates/umap/content.html
+++ b/umap/templates/umap/content.html
@@ -15,6 +15,7 @@
   <header class="wrapper row">
     {% include 'umap/navigation.html' with title=SITE_NAME %}
   </header>
+    {% include 'umap/messages.html' with title=SITE_NAME %}
 {% endblock %}
 
 {% block content %}

--- a/umap/templates/umap/messages.html
+++ b/umap/templates/umap/messages.html
@@ -1,0 +1,11 @@
+<div class="wrapper">
+    <div class="row">
+        {% if messages %}
+        <ul class="messages">
+            {% for message in messages %}
+            <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+    </div>
+</div>


### PR DESCRIPTION
Messages are already shown in the map, if any.

Useful in our case when an error is raised by the auth flow.

![Screenshot from 2023-06-15 08-30-06](https://github.com/umap-project/umap/assets/146023/f40c974d-539e-4dfb-95dd-09666b2b5f1f)
