### PR TITLE
browse datalayers overflow fix

### DIFF
--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -587,7 +587,8 @@ ul.photon-autocomplete {
     border-radius: 2px;
 }
 .leaflet-control-browse .umap-browse-datalayers {
-    height: max-content;
+    height: fit-content;
+    max-height: 40em;
     overflow-y: auto;
     resize: vertical;
 }


### PR DESCRIPTION
In my previous improvement where I suggested to set the height of datalayers to the size of the content and add a resize handle i neglected the case where a very long list of layers could make the control unusable by overflowing the available screen space.

I suggest to reintroduce a maximum height so that we have a good compromize between resizing the datalayer list and the maximum possible size.

My mistake I should have tested this more in depth before submitting my initial pull request.

![maxheight](https://github.com/umap-project/umap/assets/59520411/fd5e2890-f869-4ed5-b44f-80343faa50af)
