### PR TITLE
Set `font-display: swap;` for fonts definition

### DIFF
--- a/umap/static/umap/font.css
+++ b/umap/static/umap/font.css
@@ -9,6 +9,7 @@
          url('./font/FiraSans-Light.woff') format('woff');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face {
@@ -17,6 +18,7 @@
          url('./font/FiraSans-SemiBold.woff') format('woff');
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
 }
 
 @font-face {
@@ -25,6 +27,7 @@
          url('./font/FiraSans-LightItalic.woff') format('woff');
     font-weight: normal;
     font-style: italic;
+    font-display: swap;
 }
 
 


### PR DESCRIPTION
> Gives the font face an extremely small block period and an infinite swap period. — https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display#values

Extracted from https://github.com/umap-project/umap/pull/1093