### PR TITLE
Advanced filter should not affect non browsable layers

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -824,7 +824,7 @@ L.U.Map.include({
         this.getMap().options.advancedFilters[property] = []
       }
     })
-    this.eachDataLayer((datalayer) => {
+    this.eachBrowsableDataLayer((datalayer) => {
       datalayer.eachFeature((feature) => {
         advancedFilterKeys.forEach((property) => {
           if (feature.properties[property]) {
@@ -887,7 +887,7 @@ L.U.Map.include({
 
     const filterFeatures = function () {
       let noResults = true
-      this.eachDataLayer((datalayer) => {
+      this.eachBrowsableDataLayer((datalayer) => {
         datalayer.eachFeature(function (feature) {
           feature.properties.isVisible = true
           for (const [property, values] of Object.entries(

--- a/umap/static/umap/test/DataLayer.js
+++ b/umap/static/umap/test/DataLayer.js
@@ -373,4 +373,33 @@ describe('L.U.DataLayer', function () {
       assert.ok(qs('div.icon_container'))
     })
   })
+  describe('#advanced-filters()', function () {
+    before(function () {
+      this.server.respondWith(
+        /\/datalayer\/63\/\?.*/,
+        JSON.stringify(RESPONSES.datalayer63_GET)
+      )
+      this.map.options.advancedFilterKey = 'name'
+      this.map.createDataLayer(RESPONSES.datalayer63_GET._umap_options)
+      this.server.respond()
+    })
+    it('should show non browsable layer', function () {
+      assert.ok(qs('path[fill="SteelBlue"]'))
+    })
+    it('should allow advanced filter', function () {
+      this.map.openFilter()
+      assert.ok(qs('div.umap-filter-properties'))
+      // This one if from the normal datalayer
+      // it's name is "test", so it should be hidden
+      // by the filter
+      assert.ok(qs('path[fill="none"]'))
+      happen.click(qs('input[data-value="name poly"]'))
+      assert.notOk(qs('path[fill="none"]'))
+      // This one comes from a non browsable layer
+      // so it should not be affected by the filter
+      assert.ok(qs('path[fill="SteelBlue"]'))
+    })
+
+
+  })
 })

--- a/umap/static/umap/test/_pre.js
+++ b/umap/static/umap/test/_pre.js
@@ -253,6 +253,58 @@ var RESPONSES = {
       },
     ],
   },
+  // This one is non browsable
+  datalayer63_GET: {
+    crs: null,
+    type: 'FeatureCollection',
+    _umap_options: defaultDatalayerData({ id: 63, browsable: false }),
+    features: [
+      {
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [5.545478, 45.068383],
+              [5.545907, 45.067277],
+              [5.548439, 45.067565],
+              [5.552516, 45.06752],
+              [5.553288, 45.068217],
+              [5.549405, 45.069247],
+              [5.548224, 45.071005],
+              [5.545907, 45.071096],
+              [5.545478, 45.068383],
+            ],
+          ],
+        },
+        type: 'Feature',
+        id: 76,
+        properties: { name: 'non browsable 1' },
+      },
+      {
+        type: 'Feature',
+        properties: {
+          _umap_options: {
+            color: 'SteelBlue',
+          },
+          name: 'non browsable 2',
+        },
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [5.550542, 45.071717],
+              [5.548182, 45.071051],
+              [5.549426, 45.069232],
+              [5.553331, 45.068171],
+              [5.554812, 45.070869],
+              [5.553396, 45.072384],
+              [5.550542, 45.071717],
+            ],
+          ],
+        },
+      },
+    ],
+  },
 }
 
 sinon.fakeServer.flush = function () {


### PR DESCRIPTION
Before:

![image](https://github.com/umap-project/umap/assets/146023/5d527f67-83da-4313-a5c8-933c0cb4afde)


After:

![image](https://github.com/umap-project/umap/assets/146023/065c26af-2a4c-430c-bd45-028158416001)

Background polygons (which layer is set to "non browsable") are still visible even if they do not match the active filter.