### PR TITLE
Allow to hide advanced edit buttons

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -272,8 +272,13 @@ L.U.ContinueLineAction = L.U.BaseVertexAction.extend({
   },
 })
 
-// Leaflet.Toolbar doesn't allow twice same toolbar class…
-L.U.SettingsToolbar = L.Toolbar.Control.extend({})
+L.U.SettingsToolbar = L.Toolbar.Control.extend({
+
+  addTo: function (map) {
+    if (map.options.advancedEditControl === false && !map.permissions.isOwner()) return
+    L.Toolbar.Control.prototype.addTo.call(this, map)
+  }
+})
 L.U.DrawToolbar = L.Toolbar.Control.extend({
   initialize: function (options) {
     L.Toolbar.Control.prototype.initialize.call(this, options)

--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -1081,6 +1081,10 @@ L.U.FormBuilder = L.FormBuilder.extend({
       handler: 'DataLayersControl',
       label: L._('Display the data layers control'),
     },
+    advancedEditControl: {
+      handler: 'Switch',
+      label: L._('Show advanced edit buttons to other editors'),
+    },
     starControl: {
       handler: 'ControlChoice',
       label: L._('Display the star map button'),

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -25,6 +25,7 @@ L.Map.mergeOptions({
   editInOSMControl: false,
   editInOSMControlOptions: false,
   scaleControl: true,
+  advancedEditControl: true,
   noControl: false, // Do not render any control.
   miniMap: false,
   name: '',
@@ -161,6 +162,8 @@ L.U.Map.include({
     )
       this.options.slideshow.active = true
 
+    this.permissions = new L.U.MapPermissions(this)
+
     this.initControls()
 
     // create datalayers
@@ -233,7 +236,6 @@ L.U.Map.include({
 
     this.help = new L.U.Help(this)
     this.slideshow = new L.U.Slideshow(this, this.options.slideshow)
-    this.permissions = new L.U.MapPermissions(this)
     this.initCaptionBar()
     if (this.options.allowEdit) {
       this.editTools = new L.U.Editable(this)
@@ -1209,6 +1211,7 @@ L.U.Map.include({
     'measureControl',
     'tilelayersControl',
     'starControl',
+    'advancedEditControl',
     'easing',
   ],
 
@@ -1444,6 +1447,7 @@ L.U.Map.include({
       'options.captionBar',
       'options.captionMenus',
     ])
+    if (!this.permissions.isAnonymousMap()) UIFields.push('options.advancedEditControl')
     builder = new L.U.FormBuilder(this, UIFields, {
       callback: function () {
         this.renderControls()


### PR DESCRIPTION
This only deals with showing or hidding those buttons, but does not deal with real persmission behind (which are handled by the back-end).

There is at least one workaround possible for users (apart from using the JS console): clicking the "pencil" near to the map name in the edit bar will open the map settings. Not sure how much we want to block this.

Also we may want to be more granular: at this stage, if unclicked, it will hide the buttons for everyone but the owner, we may for example show buttons for editors but not anonymous…

cf #930

![image](https://github.com/umap-project/umap/assets/146023/2b7b6a60-a9b2-419c-9283-9a1010816b25)
