### PR TITLE
Control links target

### DIFF
--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -73,8 +73,9 @@ L.Util.escapeHTML = (s) => {
   })
   return s
 }
-L.Util.toHTML = (r) => {
+L.Util.toHTML = (r, options) => {
   if (!r) return ''
+  const target = options && options.target || 'blank'
   let ii
 
   // detect newline format
@@ -100,14 +101,14 @@ L.Util.toHTML = (r) => {
   r = r.replace(/(\[\[http)/g, '[[h_t_t_p') // Escape for avoiding clash between [[http://xxx]] and http://xxx
   r = r.replace(/({{http)/g, '{{h_t_t_p')
   r = r.replace(/(=http)/g, '=h_t_t_p') // http://xxx as query string, see https://github.com/umap-project/umap/issues/607
-  r = r.replace(/(https?:[^ \<)\n]*)/g, '<a target="_blank" href="$1">$1</a>')
-  r = r.replace(/\[\[(h_t_t_ps?:[^\]|]*?)\]\]/g, '<a target="_blank" href="$1">$1</a>')
+  r = r.replace(/(https?:[^ \<)\n]*)/g, `<a target="_${target}" href="$1">$1</a>`)
+  r = r.replace(/\[\[(h_t_t_ps?:[^\]|]*?)\]\]/g, `<a target="_${target}" href="$1">$1</a>`)
   r = r.replace(
     /\[\[(h_t_t_ps?:[^|]*?)\|(.*?)\]\]/g,
-    '<a target="_blank" href="$1">$2</a>'
+    `<a target="_${target}" href="$1">$2</a>`
   )
-  r = r.replace(/\[\[([^\]|]*?)\]\]/g, '<a href="$1">$1</a>')
-  r = r.replace(/\[\[([^|]*?)\|(.*?)\]\]/g, '<a href="$1">$2</a>')
+  r = r.replace(/\[\[([^\]|]*?)\]\]/g, `<a target="_${target}" href="$1">$1</a>`)
+  r = r.replace(/\[\[([^|]*?)\|(.*?)\]\]/g, `<a target="_${target}" href="$1">$2</a>`)
 
   // iframe
   r = r.replace(

--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -173,6 +173,8 @@ L.U.FeatureMixin = {
       'properties._umap_options.showLabel',
       'properties._umap_options.labelDirection',
       'properties._umap_options.labelInteractive',
+      'properties._umap_options.outlink',
+      'properties._umap_options.outlinkTarget',
     ]
   },
 
@@ -1044,19 +1046,6 @@ L.U.Polygon = L.Polygon.extend({
           helpEntries: 'interactive',
           inheritable: true,
         },
-      ],
-      [
-        'properties._umap_options.outlink',
-        {
-          label: L._('Link to…'),
-          helpEntries: 'outlink',
-          placeholder: 'http://...',
-          inheritable: true,
-        },
-      ],
-      [
-        'properties._umap_options.outlinkTarget',
-        { handler: 'OutlinkTarget', label: L._('Open link in…'), inheritable: true },
       ],
     ]
     return options.concat(L.U.FeatureMixin.getInteractionOptions())

--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -57,8 +57,8 @@ L.U.FeatureMixin = {
 
   view: function (e) {
     if (this.map.editEnabled) return
-    const outlink = this.properties._umap_options.outlink,
-      target = this.properties._umap_options.outlinkTarget
+    const outlink = this.getOption('outlink'),
+      target = this.getOption('outlinkTarget')
     if (outlink) {
       switch (target) {
         case 'self':

--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -1045,6 +1045,17 @@ L.U.FormBuilder = L.FormBuilder.extend({
       label: L._('Labels are clickable'),
       inheritable: true,
     },
+    outlink: {
+      label: L._('Link to…'),
+      helpEntries: 'outlink',
+      placeholder: 'http://...',
+      inheritable: true,
+    },
+    outlinkTarget: {
+      handler: 'OutlinkTarget',
+      label: L._('Open link in…'),
+      inheritable: true,
+    },
     labelKey: {
       helpEntries: 'labelKey',
       placeholder: L._('Default: name'),

--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -862,6 +862,7 @@ L.U.DataLayer = L.Evented.extend({
       'options.showLabel',
       'options.labelDirection',
       'options.labelInteractive',
+      'options.outlinkTarget',
     ]
     builder = new L.U.FormBuilder(this, popupFields, { callback: redrawCallback })
     const popupFieldset = L.DomUtil.createFieldset(

--- a/umap/static/umap/js/umap.popup.js
+++ b/umap/static/umap/js/umap.popup.js
@@ -98,6 +98,7 @@ L.U.PopupTemplate.Default = L.Class.extend({
 
   renderBody: function () {
     const template = this.feature.getOption('popupContentTemplate')
+    const target = this.feature.getOption('outlinkTarget')
     const container = L.DomUtil.create('div', 'umap-popup-container')
     let content = ''
     let properties
@@ -109,7 +110,7 @@ L.U.PopupTemplate.Default = L.Class.extend({
       properties
     )
     content = L.Util.greedyTemplate(template, properties)
-    content = L.Util.toHTML(content)
+    content = L.Util.toHTML(content, {target: target})
     container.innerHTML = content
     return container
   },

--- a/umap/static/umap/test/Util.js
+++ b/umap/static/umap/test/Util.js
@@ -84,6 +84,13 @@ describe('L.Util', function () {
       )
     })
 
+    it('should handle target option', function () {
+      assert.equal(
+        L.Util.toHTML('A simple http://osm.org link', {target: 'self'}),
+        'A simple <a href="http://osm.org" target="_self">http://osm.org</a> link'
+      )
+    })
+
     it('should handle image', function () {
       assert.equal(
         L.Util.toHTML('A simple image: {{http://osm.org/pouet.png}}'),


### PR DESCRIPTION
This PR does two things:

- make the outlink available for any feature, not only polygon: which is, one can define a link that will be opened when clicking on the feature (instead of opening a popup) cf #323 
- use the `outlinkTarget` option to also control where popup links will be opened (self/blank/parent) cf #869 

fix #869