### PR TITLE
Pass options at datalayer creation when importing from umap file

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -1038,7 +1038,7 @@ L.U.Map.include({
     if (importedData.geometry) this.options.center = this.latLng(importedData.geometry)
     const self = this
     importedData.layers.forEach((geojson) => {
-      const dataLayer = self.createDataLayer()
+      const dataLayer = self.createDataLayer(geojson._umap_options)
       dataLayer.fromUmapGeoJSON(geojson)
     })
 


### PR DESCRIPTION
fix #1042

Until now, we create an empty datalayer (which has some defaults), then we overwrite the options while calling fromGeoJSON method