### PR TITLE
🐛 — Fix UMAP_CUSTOM_TEMPLATES setting

### DIFF
--- a/umap/settings/__init__.py
+++ b/umap/settings/__init__.py
@@ -39,7 +39,10 @@ if path:
                     # Retrocompat pre 1.0, remove me in 1.1.
                     globals()['UMAP' + key[15:]] = value
                 elif key == 'UMAP_CUSTOM_TEMPLATES':
-                    globals()['TEMPLATES'][0]['DIRS'].insert(0, value)
+                    if 'DIRS' in globals()['TEMPLATES'][0]:
+                        globals()['TEMPLATES'][0]['DIRS'].insert(0, value)
+                    else:
+                        globals()['TEMPLATES'][0]['DIRS'] = [value]
                 elif key == 'UMAP_CUSTOM_STATICS':
                     globals()['STATICFILES_DIRS'].insert(0, value)
                 else:


### PR DESCRIPTION
Trying to install umap on Debian Bookworm (12) with custom templates gave me this error when trying to do `umap migrate`:
```
Loaded local config from /var/www/umap/local.py 
Traceback (most recent call last):                                                            
  File "/var/www/umap/venv-bookworm/bin/umap", line 8, in <module>
    sys.exit(main())                      
             ^^^^^^               
  File "/var/www/umap/venv-bookworm/lib/python3.11/site-packages/umap/bin/__init__.py", line 12, in main
    management.execute_from_command_line()                                                    
  File "/var/www/umap/venv-bookworm/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()                                                                         
  File "/var/www/umap/venv-bookworm/lib/python3.11/site-packages/django/core/management/__init__.py", line 382, in execute
    settings.INSTALLED_APPS                                                                   
  File "/var/www/umap/venv-bookworm/lib/python3.11/site-packages/django/conf/__init__.py", line 102, in __getattr__
    self._setup(name)                                                                         
  File "/var/www/umap/venv-bookworm/lib/python3.11/site-packages/django/conf/__init__.py", line 89, in _setup
    self._wrapped = Settings(settings_module)                                                 
                    ^^^^^^^^^^^^^^^^^^^^^^^^^                                                 
  File "/var/www/umap/venv-bookworm/lib/python3.11/site-packages/django/conf/__init__.py", line 217, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/var/www/umap/venv-bookworm/lib/python3.11/site-packages/umap/settings/__init__.py", line 42, in <module>
    globals()['TEMPLATES'][0]['DIRS'].insert(0, value)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^                                                         
KeyError: 'DIRS'  
```

Here’s the fix I used.