### PR TITLE
Expose 'locale' parameter in templates

### DIFF
--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -521,7 +521,7 @@ L.U.Help = L.Class.extend({
 
   formatURL: `${L._(
     'Supported variables that will be dynamically replaced'
-  )}: {bbox}, {lat}, {lng}, {zoom}, {east}, {north}..., {left}, {top}...`,
+  )}: {bbox}, {lat}, {lng}, {zoom}, {east}, {north}..., {left}, {top}..., locale`,
   formatIconSymbol: L._(
     'Symbol can be either a unicode character or an URL. You can use feature properties as variables: ex.: with "http://myserver.org/images/{name}.png", the {name} variable will be replaced by the "name" value of each marker.'
   ),

--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -485,6 +485,7 @@ L.U.FeatureMixin = {
     properties.lon = center.lng
     properties.lng = center.lng
     properties.rank = this.getRank() + 1
+    if (L.locale) properties.locale = L.locale
     if (typeof this.getMeasure !== 'undefined') {
       properties.measure = this.getMeasure()
     }

--- a/umap/static/umap/test/Feature.js
+++ b/umap/static/umap/test/Feature.js
@@ -30,15 +30,15 @@ describe('L.U.FeatureMixin', function () {
 
     it('should toggle edit panel on shift-clic', function () {
       enableEdit()
-      happen.click(qs('path[fill="DarkBlue"]'), {shiftKey: true})
+      happen.click(qs('path[fill="DarkBlue"]'), { shiftKey: true })
       assert.ok(qs('form#umap-feature-properties'))
-      happen.click(qs('path[fill="DarkBlue"]'), {shiftKey: true})
+      happen.click(qs('path[fill="DarkBlue"]'), { shiftKey: true })
       assert.notOk(qs('form#umap-feature-properties'))
     })
 
     it('should open datalayer edit panel on ctrl-shift-clic', function () {
       enableEdit()
-      happen.click(qs('path[fill="DarkBlue"]'), {shiftKey: true, ctrlKey: true})
+      happen.click(qs('path[fill="DarkBlue"]'), { shiftKey: true, ctrlKey: true })
       assert.ok(qs('div.umap-layer-properties-container'))
     })
 
@@ -209,12 +209,34 @@ describe('L.U.FeatureMixin', function () {
   })
 
   describe('#openPopup()', function () {
+    let poly
+    before(function () {
+      this.datalayer.eachLayer(function (layer) {
+        if (!poly && layer instanceof L.Polygon) {
+          poly = layer
+        }
+      })
+    })
+
     it('should open a popup on click', function () {
       assert.notOk(qs('.leaflet-popup-content'))
       happen.click(qs('path[fill="DarkBlue"]'))
       var title = qs('.leaflet-popup-content')
       assert.ok(title)
-      assert.ok(title.innerHTML.indexOf('name poly'))
+      assert.include(title.innerHTML, 'name poly')
+      happen.click(qs('#map')) // Close popup
+    })
+
+    it('should handle locale parameter inside description', function (done) {
+      poly.properties.description = "This is a link to [[https://domain.org/?locale={locale}|Wikipedia]]"
+      happen.click(qs('path[fill="DarkBlue"]'))
+      window.setTimeout(function () {
+        let content = qs('.umap-popup-container')
+        assert.ok(content)
+        assert.include(content.innerHTML, '<a href="https://domain.org/?locale=en" target="_blank">Wikipedia</a>')
+        happen.click(qs('#map')) // Close popup
+        done()
+      }, 500) // No idea why needed…
     })
   })
 

--- a/umap/static/umap/test/_pre.js
+++ b/umap/static/umap/test/_pre.js
@@ -185,6 +185,7 @@ function initMap(options) {
       },
       name: 'name of the map',
       description: 'The description of the map',
+      locale: 'en',
       allowEdit: true,
       moreControl: true,
       scaleControl: true,


### PR DESCRIPTION
Useful for example to adapt the outgoing link according to current user locale

fix #183