### PR TITLE
Use LANGUAGE_CODE instead of locale name for browser APIs

### DIFF
--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -219,7 +219,7 @@ L.Util.sortFeatures = (features, sortKey) => {
       score = valA
         .toString()
         .toLowerCase()
-        .localeCompare(valB.toString().toLowerCase(), L.locale || 'en', {
+        .localeCompare(valB.toString().toLowerCase(), L.lang || 'en', {
           sensitivity: 'base',
           ignorePunctuation: true,
           numeric: true,
@@ -537,7 +537,7 @@ L.U.Help = L.Class.extend({
 
   formatURL: `${L._(
     'Supported variables that will be dynamically replaced'
-  )}: {bbox}, {lat}, {lng}, {zoom}, {east}, {north}..., {left}, {top}..., locale`,
+  )}: {bbox}, {lat}, {lng}, {zoom}, {east}, {north}..., {left}, {top}..., locale, lang`,
   formatIconSymbol: L._(
     'Symbol can be either a unicode character or an URL. You can use feature properties as variables: ex.: with "http://myserver.org/images/{name}.png", the {name} variable will be replaced by the "name" value of each marker.'
   ),

--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -500,6 +500,7 @@ L.U.FeatureMixin = {
     properties.lng = center.lng
     properties.rank = this.getRank() + 1
     if (L.locale) properties.locale = L.locale
+    if (L.lang) properties.lang = L.lang
     if (typeof this.getMeasure !== 'undefined') {
       properties.measure = this.getMeasure()
     }

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -65,8 +65,15 @@ L.U.Map.include({
   ],
 
   initialize: function (el, geojson) {
-    if (geojson.properties && geojson.properties.locale)
+    // Locale name (pt_PT, en_US…)
+    // To be used for Django localization
+    if (geojson.properties.locale)
       L.setLocale(geojson.properties.locale)
+
+    // Language code (pt-pt, en-us…)
+    // To be used in javascript APIs
+    if (geojson.properties.lang)
+      L.lang = geojson.properties.lang
 
     // Don't let default autocreation of controls
     const zoomControl =

--- a/umap/views.py
+++ b/umap/views.py
@@ -423,11 +423,12 @@ class MapDetailMixin:
             properties["shortUrl"] = self.get_short_url()
 
         if settings.USE_I18N:
-            locale = settings.LANGUAGE_CODE
+            lang = settings.LANGUAGE_CODE
             # Check attr in case the middleware is not active
             if hasattr(self.request, "LANGUAGE_CODE"):
-                locale = self.request.LANGUAGE_CODE
-            locale = to_locale(locale)
+                lang = self.request.LANGUAGE_CODE
+            properties["lang"] = lang
+            locale = to_locale(lang)
             properties["locale"] = locale
             context["locale"] = locale
         user = self.request.user


### PR DESCRIPTION
We use locale name (pt_PT) instead of the language code to use in localeCompare, which is wrong.

Given that both need to exist, let's also expose it in extendedProperties.

fix #1187