### PR TITLE
Fix tooltip anchor not updated anymore according to the direction

### DIFF
--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -580,6 +580,20 @@ L.U.Marker = L.Marker.extend({
     this.resetTooltip()
   },
 
+  _getTooltipAnchor: function () {
+    const anchor = this.options.icon.options.tooltipAnchor,
+      direction = this.getOption('labelDirection')
+    if (direction === 'left') {
+      anchor.x *= -1
+    } else if (direction === 'bottom') {
+      anchor.x = 0
+      anchor.y = 0
+    } else if (direction === 'top') {
+      anchor.x = 0
+    }
+    return anchor
+  },
+
   disconnectFromDataLayer: function (datalayer) {
     this.options.icon.datalayer = null
     L.U.FeatureMixin.disconnectFromDataLayer.call(this, datalayer)


### PR DESCRIPTION
This is a change in Leaflet 1.7.0

cf https://github.com/Leaflet/Leaflet/issues/7302

Before:

![image](https://github.com/umap-project/umap/assets/146023/ce42ea54-f463-49ef-bf29-32e0a6406dee)


After:

![image](https://github.com/umap-project/umap/assets/146023/8685ed2c-b776-40f5-9424-7996213ee30f)
