### PR TITLE
Fallback user to dashboard after OAuth process

### DIFF
--- a/umap/templates/umap/login_popup_end.html
+++ b/umap/templates/umap/login_popup_end.html
@@ -6,7 +6,7 @@
       window.opener.umap_proceed()
     } else {
       // Trade off as Twitter does not allow us to access window.opener
-      window.location.href = '{{ request.user.get_url }}'
+      window.location.href = '{% url "user_dashboard" %}'
     }
   }
 


### PR DESCRIPTION
Now that we have a dashboard page, this makes more sense than the "public profile" page.