### PR TITLE
Fix if unmodified pre 1.3.0

### DIFF
--- a/umap/utils.py
+++ b/umap/utils.py
@@ -112,7 +112,7 @@ def gzip_file(from_path, to_path):
     with open(from_path, "rb") as f_in:
         with gzip.open(to_path, "wb") as f_out:
             f_out.writelines(f_in)
-    os.utime(to_path, (stat.st_mtime, stat.st_mtime))
+    os.utime(to_path, ns=(stat.st_mtime_ns, stat.st_mtime_ns))
 
 
 def is_ajax(request):


### PR DESCRIPTION
Prior to 1.3.0, uMap was not setting the gzip mtime, so it was
whatever the time it get requested at first.
Since 1.3.0:
- when creating the geojson.gzip, we also force its mtime to be
  the geojson one
- we replaced If-Match by If-Unmodified, which relies on Last-Modified

When uMap is served by a proxy like Nginx (and X-Accel-Redirect),
and if user accepts gzip, then the Last-Modified would be the gzip
one, not the flat geojson one.

So when comparing that value in a subsequent update, we need to
compare with the correct value.
    
fix #1212 