### PR TITLE
Fix popup panel not opening from the data browser

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -671,6 +671,9 @@ L.U.DataLayer.addInitHook(function () {
 L.U.Map.include({
   _openBrowser: function () {
     const browserContainer = L.DomUtil.create('div', 'umap-browse-data')
+    // HOTFIX. Remove when this is merged and released:
+    // https://github.com/Leaflet/Leaflet/pull/9052
+    L.DomEvent.disableClickPropagation(browserContainer)
 
     const title = L.DomUtil.add(
       'h3',

--- a/umap/static/umap/js/umap.popup.js
+++ b/umap/static/umap/js/umap.popup.js
@@ -63,8 +63,8 @@ L.U.Popup.Panel = L.U.Popup.extend({
     return button
   },
 
-  update: function () {
-    this.feature.map.ui.openPanel({
+  onAdd: function (map) {
+    map.ui.openPanel({
       data: { html: this._content },
       actions: [this.allButton()],
     })
@@ -72,12 +72,9 @@ L.U.Popup.Panel = L.U.Popup.extend({
 
   onRemove: function (map) {
     map.ui.closePanel()
-    L.U.Popup.prototype.onRemove.call(this, map)
   },
 
-  _initLayout: function () {
-    this._container = L.DomUtil.create('span')
-  },
+  update: function () {},
   _updateLayout: function () {},
   _updatePosition: function () {},
   _adjustPan: function () {},


### PR DESCRIPTION
This is since recent Leaflet upgrade.

The issue was:
- clicking on feature in the data browser replaces the panel content
- then the clicked link (the feature name or the little glass icon) is removed
- thus it is detached from the DOM
- and specially from its parent on which disableClickPropagation was called
- so Leaflet fails to prevent click propagation
- so the map received the click, and thus it call the onRemove method on
  the panel, as expected (clicking on the map always close the current
  open popup, if any)

This could be removed when this is released:

https://github.com/Leaflet/Leaflet/pull/9052


Before:

[Screencast from 2023-07-31 21-09-38.webm](https://github.com/umap-project/umap/assets/146023/4420015e-b048-4ef3-86a4-a91beb61fa93)


After:

[Screencast from 2023-07-31 21-08-36.webm](https://github.com/umap-project/umap/assets/146023/077d3ac7-0389-41bd-b4b6-16ea683f66e2)
