### PR TITLE
Better control of default view

### DIFF
--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -417,7 +417,16 @@ L.FormBuilder.DataLayerSwitcher = L.FormBuilder.Select.extend({
   },
 })
 
-L.FormBuilder.onLoadPanel = L.FormBuilder.Select.extend({
+L.FormBuilder.DefaultView = L.FormBuilder.Select.extend({
+  selectOptions: [
+    ['center', L._('Saved center and zoom')],
+    ['bounds', L._('Layers bounds')],
+    ['latest', L._('Latest feature')],
+    ['locate', L._('User location')],
+  ],
+})
+
+L.FormBuilder.OnLoadPanel = L.FormBuilder.Select.extend({
   selectOptions: [
     ['none', L._('None')],
     ['caption', L._('Caption')],
@@ -1008,8 +1017,12 @@ L.U.FormBuilder = L.FormBuilder.extend({
       label: L._('Do you want to display the scale control?'),
     },
     onLoadPanel: {
-      handler: 'onLoadPanel',
+      handler: 'OnLoadPanel',
       label: L._('Do you want to display a panel on load?'),
+    },
+    defaultView: {
+      handler: 'DefaultView',
+      label: L._('Default view'),
     },
     displayPopupFooter: {
       handler: 'Switch',


### PR DESCRIPTION
![image](https://github.com/umap-project/umap/assets/146023/3c230bf1-9ce6-492b-8189-c5dd83450c6f)


fix #40

Let the user choose the map behaviour to define default view:

- saved center and zoom: current behaviour, and default
- bounds: will compute the view to fit all the map data, useful for having the same view in different sized devices (mobile…)
- latest feature: useful in some situation, where the map tracks some progress (travel…), this will certainly needs a bit more iterations, mainly to have an explicit default datalayer
- user location: this option used to exist but was then removed, I can remember when and why

Note: when there is a URL hash, the hash will be used