### PR TITLE
Only call propagateShow at init if layer is visible

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -663,7 +663,7 @@ L.U.DataLayer.include({
 L.U.DataLayer.addInitHook(function () {
   this.on('hide', this.propagateHide)
   this.on('show', this.propagateShow)
-  this.propagateShow()
+  if (this.isVisible()) this.propagateShow()
 })
 
 L.U.Map.include({


### PR DESCRIPTION
fix #1263

We were calling popagateShow at datalayer init, which then
add a listener to "loaded" event, and then do the propagate.
So when the layer is hidden at load, when dragging it in the
datalayers list, it will be loaded (because we need to save it
with its new position) and it will appears as shown whatever
its real status.
