### PR TITLE
fix: correct changelog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # uMap project
 
 [![Requirements Status](https://requires.io/github/umap-project/umap/requirements.svg?branch=master)](https://requires.io/github/umap-project/umap/requirements/?branch=master)
-[![Join the chat at https://gitter.im/umap-project/umap](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/umap-project/umap?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Documentation Status](https://readthedocs.org/projects/umap-project/badge/?version=latest)](http://umap-project.readthedocs.io/en/latest/?badge=latest)[![Build Status](https://travis-ci.org/umap-project/umap.svg?branch=master)](https://travis-ci.org/umap-project/umap)
+[![Join the chat at https://gitter.im/umap-project/umap](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/umap-project/umap?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Documentation Status](https://readthedocs.org/projects/umap-project/badge/?version=latest)](http://umap-project.readthedocs.io/en/master/?badge=latest)[![Build Status](https://travis-ci.org/umap-project/umap.svg?branch=master)](https://travis-ci.org/umap-project/umap)
 
 ## About
 
@@ -13,4 +13,4 @@ Built on top of Django and Leaflet.
 
 ## Installation and configuration
 
-See [developer documentation](https://umap-project.readthedocs.io/en/latest/install/).
+See [developer documentation](https://umap-project.readthedocs.io/en/master/install/).

--- a/umap/settings/base.py
+++ b/umap/settings/base.py
@@ -2,9 +2,9 @@
 # Import global settings to make it easier to extend settings.
 from email.utils import parseaddr
 
-from django.template.defaultfilters import slugify
-from django.conf.locale import LANG_INFO
 import environ
+from django.conf.locale import LANG_INFO
+from django.template.defaultfilters import slugify
 
 env = environ.Env()
 
@@ -137,6 +137,7 @@ FORM_RENDERER = "django.forms.renderers.DjangoDivFormRenderer"
 # =============================================================================
 
 import os
+
 import umap as project_module
 
 PROJECT_DIR = os.path.dirname(os.path.realpath(project_module.__file__))

--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -911,7 +911,7 @@ L.U.Map.include({
         leaflet: 'http://leafletjs.com',
         django: 'https://www.djangoproject.com',
         umap: 'http://wiki.openstreetmap.org/wiki/UMap',
-        changelog: 'https://umap-project.readthedocs.io/en/latest/changelog/',
+        changelog: 'https://umap-project.readthedocs.io/en/master/changelog/',
         version: this.options.umap_version,
       }
     umapCredit.innerHTML = L._(

--- a/umap/templates/umap/content_footer.html
+++ b/umap/templates/umap/content_footer.html
@@ -2,7 +2,7 @@
 <footer>
   <a href="https://wiki.openstreetmap.org/wiki/UMap" class="branding">uMap</a>
   an OpenStreetMap project
-  (version <a href="https://umap-project.readthedocs.io/en/latest/changelog/">{{ UMAP_VERSION }}</a>)
+  (version <a href="https://umap-project.readthedocs.io/en/master/changelog/">{{ UMAP_VERSION }}</a>)
   {% get_language_info_list for LANGUAGES as languages %}
   <form action="{% url "set_language" %}" method="post" class="i18n_switch">
     {% csrf_token %}


### PR DESCRIPTION
Hello 👋 

Small fix and maybe you prefer that i link to this page https://umap-project.readthedocs.io/en/master/changelog/

but as it was not really up to date i chose to go for github and to link to the specific version  :) 
but i'm ready to change if you prefer

Regards

