### PR TITLE
Remove default center to prevent multiple map initialisations

### DIFF
--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -420,7 +420,7 @@ L.FormBuilder.DataLayerSwitcher = L.FormBuilder.Select.extend({
 L.FormBuilder.DefaultView = L.FormBuilder.Select.extend({
   selectOptions: [
     ['center', L._('Saved center and zoom')],
-    ['bounds', L._('Layers bounds')],
+    ['data', L._('Fit all data')],
     ['latest', L._('Latest feature')],
     ['locate', L._('User location')],
   ],

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -310,6 +310,7 @@ L.U.Map.include({
       icon: 'umap-fake-class',
       iconLoading: 'umap-fake-class',
       flyTo: this.options.easing,
+      onLocationError: (err) => this.ui.alert({content: err.message})
     })
     this._controls.fullscreen = new L.Control.Fullscreen({
       title: { false: L._('View Fullscreen'), true: L._('Exit Fullscreen') },
@@ -632,11 +633,17 @@ L.U.Map.include({
     }
   },
 
+  _setDefaultCenter: function () {
+      this.options.center = this.latLng(this.options.center)
+      this.setView(this.options.center, this.options.zoom)
+  },
+
   initCenter: function () {
     if (this.options.hash && this._hash.parseHash(location.hash)) {
       // FIXME An invalid hash will cause the load to fail
       this._hash.update()
     } else if (this.options.defaultView === 'locate' && !this.options.noControl) {
+      this.once('locationerror', this._setDefaultCenter)
       this._controls.locate.start()
     } else if (this.options.defaultView === 'bounds') {
       this.onceDataLoaded(() => this.fitBounds(this.getLayersBounds()))
@@ -647,8 +654,7 @@ L.U.Map.include({
         if (feature) feature.zoomTo()
       })
     } else {
-      this.options.center = this.latLng(this.options.center)
-      this.setView(this.options.center, this.options.zoom)
+      this._setDefaultCenter()
     }
   },
 

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -1,8 +1,6 @@
 L.Map.mergeOptions({
   overlay: null,
   datalayers: [],
-  center: [50, 4],
-  zoom: 6,
   hash: true,
   default_color: 'DarkBlue',
   default_smoothFactor: 1.0,
@@ -86,10 +84,11 @@ L.U.Map.include({
     geojson.properties.fullscreenControl = false
     L.Util.setBooleanFromQueryString(geojson.properties, 'scrollWheelZoom')
 
-    // Before calling parent initialize
-    if (geojson.geometry) this.options.center = this.latLng(geojson.geometry)
 
     L.Map.prototype.initialize.call(this, el, geojson.properties)
+
+    // After calling parent initialize, as we are doing initCenter our-selves
+    if (geojson.geometry) this.options.center = this.latLng(geojson.geometry)
 
     this.ui = new L.U.UI(this._container)
     this.xhr = new L.U.Xhr(this.ui)

--- a/umap/static/umap/test/Map.Init.js
+++ b/umap/static/umap/test/Map.Init.js
@@ -1,0 +1,16 @@
+describe('L.U.Map.initialize', function () {
+  afterEach(function () {
+    resetMap()
+  })
+
+  it("should not show a minimap by default", function () {
+    this.map = initMap()
+    assert.notOk(qs('.leaflet-control-minimap'))
+  })
+
+  it("should show a minimap", function () {
+    this.map = initMap({ miniMap: true })
+    assert.ok(qs('.leaflet-control-minimap'))
+  })
+
+})

--- a/umap/static/umap/test/Map.Init.js
+++ b/umap/static/umap/test/Map.Init.js
@@ -3,14 +3,44 @@ describe('L.U.Map.initialize', function () {
     resetMap()
   })
 
-  it("should not show a minimap by default", function () {
-    this.map = initMap()
-    assert.notOk(qs('.leaflet-control-minimap'))
+  describe('Controls', function () {
+    it('should not show a minimap by default', function () {
+      this.map = initMap()
+      assert.notOk(qs('.leaflet-control-minimap'))
+    })
+
+    it('should show a minimap', function () {
+      this.map = initMap({ miniMap: true })
+      assert.ok(qs('.leaflet-control-minimap'))
+    })
   })
 
-  it("should show a minimap", function () {
-    this.map = initMap({ miniMap: true })
-    assert.ok(qs('.leaflet-control-minimap'))
-  })
+  describe('DefaultView', function () {
+    it('should set default view in default mode without data', function (done) {
+      this.map = initMap({ datalayers: [] })
+      // Did not find a better way to wait for tiles to be actually loaded
+      window.setTimeout(() => {
+        assert.ok(qs('#map .leaflet-tile-pane img.leaflet-tile.leaflet-tile-loaded'))
+        done()
+      }, 1000)
+    })
 
+    it("should set default view in 'data' mode without data", function (done) {
+      this.map = initMap({ datalayers: [], defaultView: 'data' })
+      // Did not find a better way to wait for tiles to be actually loaded
+      window.setTimeout(() => {
+        assert.ok(qs('#map .leaflet-tile-pane img.leaflet-tile.leaflet-tile-loaded'))
+        done()
+      }, 1000)
+    })
+
+    it("should set default view in 'latest' mode without data", function (done) {
+      this.map = initMap({ datalayers: [], defaultView: 'latest' })
+      // Did not find a better way to wait for tiles to be actually loaded
+      window.setTimeout(() => {
+        assert.ok(qs('#map .leaflet-tile-pane img.leaflet-tile.leaflet-tile-loaded'))
+        done()
+      }, 1000)
+    })
+  })
 })

--- a/umap/static/umap/test/_pre.js
+++ b/umap/static/umap/test/_pre.js
@@ -107,10 +107,6 @@ var defaultDatalayerData = function (custom) {
 
 function initMap(options) {
   default_options = {
-    geometry: {
-      type: 'Point',
-      coordinates: [5.0592041015625, 52.05924589011585],
-    },
     type: 'Feature',
     properties: {
       umap_id: 42,
@@ -197,7 +193,7 @@ function initMap(options) {
       allowEdit: true,
       moreControl: true,
       scaleControl: true,
-      miniMap: true,
+      miniMap: false,
       datalayersControl: true,
       displayCaptionOnLoad: false,
       displayPopupFooter: false,
@@ -205,7 +201,12 @@ function initMap(options) {
     },
   }
   default_options.properties.datalayers.push(defaultDatalayerData())
+  options = options || {}
   options.properties = L.extend({}, default_options.properties, options)
+  options.geometry = {
+    type: 'Point',
+    coordinates: [5.0592041015625, 52.05924589011585],
+  }
   return new L.U.Map('map', options)
 }
 

--- a/umap/static/umap/test/index.html
+++ b/umap/static/umap/test/index.html
@@ -67,6 +67,7 @@
     </script>
     <script src="./_pre.js"></script>
     <script src="./Map.js"></script>
+    <script src="./Map.Init.js"></script>
     <script src="./DataLayer.js"></script>
     <script src="./TableEditor.js"></script>
     <script src="./Feature.js"></script>


### PR DESCRIPTION
We want to init the map view once, in our initCenter method, so we remove any center from the option, to prevent Leaflet to init the map on this centers

fix #1277

closes #1281 
closes #1282 