### PR TITLE
Restore help button icon

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -1010,7 +1010,7 @@ L.U.Map.include({
     disable.href = '#'
     disable.textContent = L._('Disable editing')
     disable.title = `${disable.textContent} (Ctrl+E)`
-    this.help.button(container, 'edit')
+    this.help.link(container, 'edit')
     if (this.options.user) {
       const userLabel = L.DomUtil.add(
         'a',

--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -428,10 +428,9 @@ L.U.Help = L.Class.extend({
     return typeof this[name] === 'function' ? this[name]() : this[name]
   },
 
-  button: function (container, entries) {
-    const helpButton = L.DomUtil.create('a', 'umap-help-button', container)
+  button: function (container, entries, classname) {
+    const helpButton = L.DomUtil.create('a', classname || 'umap-help-button', container)
     helpButton.href = '#'
-    helpButton.textContent = L._("Help")
     if (entries) {
       L.DomEvent.on(helpButton, 'click', L.DomEvent.stop).on(
         helpButton,
@@ -443,6 +442,12 @@ L.U.Help = L.Class.extend({
         this
       )
     }
+    return helpButton
+  },
+
+  link: function (container, entries) {
+    const helpButton = this.button(container, entries, 'umap-help-link')
+    helpButton.textContent = L._("Help")
     return helpButton
   },
 

--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -348,6 +348,19 @@ ul.photon-autocomplete {
     float: right;
 }
 .umap-help-button {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    margin-left: 5px;
+    background-position: -4px -4px;
+    background-repeat: no-repeat;
+    background-image: url('./img/16.svg');
+    vertical-align: middle;
+}
+.dark .umap-help-button {
+    background-image: url('./img/16-white.svg');
+ }
+.umap-help-link {
     float: right;
     margin-right: 20px;
 }


### PR DESCRIPTION
While changing the edit header help link, I've changed all help buttons, which was not intended.

Before:

![image](https://github.com/umap-project/umap/assets/146023/416e2151-d91c-4973-a108-055ae3529d1a)


After:

![image](https://github.com/umap-project/umap/assets/146023/aef4f2cc-aa21-4d7a-8b75-e3f3834d7506)
