### PR TITLE
Try to fix remote datalayer not sending dataloaded

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -406,12 +406,19 @@ L.U.Map.include({
       if (dataToload === 0) dataLoaded()
     }
     this.eachDataLayer(function (datalayer) {
-      if (force && !datalayer.hasDataLoaded()) datalayer.show()
-      if (datalayer.showAtLoad() || force) datalayer.onceLoaded(decrementToLoad)
-      else decrementToLoad()
-      if (datalayer.showAtLoad() || force)
+      if (force && !datalayer.hasDataLoaded()) {
+        datalayer.show()
+      }
+      if (datalayer.showAtLoad() || force) {
+        datalayer.onceLoaded(decrementToLoad)
+      } else {
+        decrementToLoad()
+      }
+      if (datalayer.showAtLoad() || force) {
         datalayer.onceDataLoaded(decrementDataToLoad)
-      else decrementDataToLoad()
+      } else {
+        decrementDataToLoad({ sourceTarget: datalayer })
+      }
     })
     if (total === 0) {
       // no datalayer

--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -274,7 +274,7 @@ L.U.DataLayer = L.Evented.extend({
   },
 
   onMoveEnd: function (e) {
-    if (this.isRemoteLayer()) this.fetchRemoteData()
+    if (this.isRemoteLayer() && this.showAtZoom()) this.fetchRemoteData()
   },
 
   onZoomEnd: function (e) {
@@ -409,7 +409,6 @@ L.U.DataLayer = L.Evented.extend({
 
   fetchRemoteData: function (force) {
     if (!this.isRemoteLayer()) return
-    if (!this.showAtZoom()) return
     if (!this.options.remoteData.dynamic && this.hasDataLoaded() && !force) return
     if (!this.isVisible()) return
     let url = this.map.localizeUrl(this.options.remoteData.url)


### PR DESCRIPTION
This occurs when the remote datalayer has a min or maxZoom defined, and the map is loaded outside those zooms. In this case, when calling fetchRemoteData, the fetch was never done, nor the final call to fromGeoJSON, which would have sent the dataloaded event.