### PR TITLE
Use css width for img custom width

### DIFF
--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -129,7 +129,7 @@ L.Util.toHTML = (r, options) => {
 
   // images
   r = r.replace(/{{([^\]|]*?)}}/g, '<img src="$1">')
-  r = r.replace(/{{([^|]*?)\|(\d*?)}}/g, '<img src="$1" width="$2">')
+  r = r.replace(/{{([^|]*?)\|(\d*?)(px)?}}/g, '<img src="$1" style="width:$2px;min-width:$2px;">')
 
   //Unescape http
   r = r.replace(/(h_t_t_p)/g, 'http')

--- a/umap/static/umap/test/Util.js
+++ b/umap/static/umap/test/Util.js
@@ -108,7 +108,7 @@ describe('L.Util', function () {
     it('should handle image with width', function () {
       assert.equal(
         L.Util.toHTML('A simple image: {{http://osm.org/pouet.png|100}}'),
-        'A simple image: <img width="100" src="http://osm.org/pouet.png">'
+        'A simple image: <img style="width:100px;min-width:100px;" src="http://osm.org/pouet.png">'
       )
     })
 


### PR DESCRIPTION
The width attribute is the intrinsic width of the image, and thus it will not overwrite the default CSS

cf https://forum.openstreetmap.fr/t/bugs-divers-relevees-sur-une-umap-absent-sur-une-autre/17254/5

Before (with forced width of 100px):

![image](https://github.com/umap-project/umap/assets/146023/780c85b7-ed54-4d6f-a838-b0236369a8f5)


After (idem):

![image](https://github.com/umap-project/umap/assets/146023/35c17624-351f-4c26-9293-84b66cac3659)
