### PR TITLE
Merge OWNER and EDITORS into RESTRICTED level

### DIFF
--- a/umap/forms.py
+++ b/umap/forms.py
@@ -53,8 +53,8 @@ class DataLayerPermissionsForm(forms.ModelForm):
 
 class AnonymousDataLayerPermissionsForm(forms.ModelForm):
     STATUS = (
-        (Map.ANONYMOUS, _("Everyone can edit")),
-        (Map.OWNER, _("Only editable with secret edit link")),
+        (DataLayer.OPEN, _("Everyone can edit")),
+        (DataLayer.RESTRICTED, _("Only editable with secret edit link")),
     )
 
     edit_status = forms.ChoiceField(choices=STATUS)

--- a/umap/models.py
+++ b/umap/models.py
@@ -41,7 +41,7 @@ def get_default_share_status():
 
 
 def get_default_edit_status():
-    return settings.UMAP_DEFAULT_EDIT_STATUS or Map.OWNER
+    return settings.UMAP_DEFAULT_EDIT_STATUS or DataLayer.RESTRICTED
 
 
 class NamedModel(models.Model):
@@ -300,13 +300,11 @@ class DataLayer(NamedModel):
     Layer to store Features in.
     """
 
-    ANONYMOUS = 1
-    EDITORS = 2
-    OWNER = 3
+    OPEN = 1
+    RESTRICTED = 2
     EDIT_STATUS = (
-        (ANONYMOUS, _("Everyone")),
-        (EDITORS, _("Editors only")),
-        (OWNER, _("Owner only")),
+        (OPEN, _("Everyone")),
+        (RESTRICTED, _("Restricted to editors")),
     )
 
     map = models.ForeignKey(Map, on_delete=models.CASCADE)
@@ -428,7 +426,7 @@ class DataLayer(NamedModel):
         if can:
             # Owner or editor, no need for further checks.
             return can
-        if self.edit_status == self.ANONYMOUS:
+        if self.edit_status == self.OPEN:
             can = True
         return can
 

--- a/umap/tests/integration/test_anonymous_owned_map.py
+++ b/umap/tests/integration/test_anonymous_owned_map.py
@@ -45,7 +45,7 @@ def test_map_load_with_anonymous(anonymap, live_server, page):
 def test_map_load_with_anonymous_but_editable_layer(
     anonymap, live_server, page, datalayer
 ):
-    datalayer.edit_status = DataLayer.ANONYMOUS
+    datalayer.edit_status = DataLayer.OPEN
     datalayer.save()
     page.goto(f"{live_server.url}{anonymap.get_absolute_url()}")
     map_el = page.locator("#map")

--- a/umap/tests/integration/test_owned_map.py
+++ b/umap/tests/integration/test_owned_map.py
@@ -57,7 +57,7 @@ def test_map_update_with_anonymous(map, live_server, page):
 def test_map_update_with_anonymous_but_editable_datalayer(
     map, datalayer, live_server, page
 ):
-    datalayer.edit_status = DataLayer.ANONYMOUS
+    datalayer.edit_status = DataLayer.OPEN
     datalayer.save()
     page.goto(f"{live_server.url}{map.get_absolute_url()}")
     map_el = page.locator("#map")

--- a/umap/tests/test_datalayer.py
+++ b/umap/tests/test_datalayer.py
@@ -83,13 +83,13 @@ def test_should_remove_old_versions_on_save(datalayer, map, settings):
 
 
 def test_anonymous_cannot_edit_in_editors_mode(datalayer):
-    datalayer.edit_status = DataLayer.EDITORS
+    datalayer.edit_status = DataLayer.RESTRICTED
     datalayer.save()
     assert not datalayer.can_edit()
 
 
 def test_owner_can_edit_in_editors_mode(datalayer, user):
-    datalayer.edit_status = DataLayer.EDITORS
+    datalayer.edit_status = DataLayer.RESTRICTED
     datalayer.save()
     assert datalayer.can_edit(datalayer.map.owner)
 
@@ -98,19 +98,19 @@ def test_editor_can_edit_in_editors_mode(datalayer, user):
     map = datalayer.map
     map.editors.add(user)
     map.save()
-    datalayer.edit_status = DataLayer.EDITORS
+    datalayer.edit_status = DataLayer.RESTRICTED
     datalayer.save()
     assert datalayer.can_edit(user)
 
 
 def test_anonymous_can_edit_in_public_mode(datalayer):
-    datalayer.edit_status = DataLayer.ANONYMOUS
+    datalayer.edit_status = DataLayer.OPEN
     datalayer.save()
     assert datalayer.can_edit()
 
 
 def test_owner_can_edit_in_public_mode(datalayer, user):
-    datalayer.edit_status = DataLayer.ANONYMOUS
+    datalayer.edit_status = DataLayer.OPEN
     datalayer.save()
     assert datalayer.can_edit(datalayer.map.owner)
 
@@ -119,13 +119,13 @@ def test_editor_can_edit_in_public_mode(datalayer, user):
     map = datalayer.map
     map.editors.add(user)
     map.save()
-    datalayer.edit_status = DataLayer.ANONYMOUS
+    datalayer.edit_status = DataLayer.OPEN
     datalayer.save()
     assert datalayer.can_edit(user)
 
 
 def test_anonymous_cannot_edit_in_anonymous_owner_mode(datalayer):
-    datalayer.edit_status = DataLayer.OWNER
+    datalayer.edit_status = DataLayer.RESTRICTED
     datalayer.save()
     map = datalayer.map
     map.owner = None
@@ -134,7 +134,7 @@ def test_anonymous_cannot_edit_in_anonymous_owner_mode(datalayer):
 
 
 def test_anonymous_can_edit_in_anonymous_owner_but_public_mode(datalayer):
-    datalayer.edit_status = DataLayer.ANONYMOUS
+    datalayer.edit_status = DataLayer.OPEN
     datalayer.save()
     map = datalayer.map
     map.owner = None

--- a/umap/tests/test_datalayer_views.py
+++ b/umap/tests/test_datalayer_views.py
@@ -191,7 +191,7 @@ def test_update_readonly(client, datalayer, map, post_data, settings):
 def test_anonymous_owner_can_edit_in_anonymous_owner_mode(
     datalayer, cookieclient, anonymap, post_data
 ):
-    datalayer.edit_status = DataLayer.OWNER
+    datalayer.edit_status = DataLayer.RESTRICTED
     datalayer.save()
     url = reverse("datalayer_update", args=(anonymap.pk, datalayer.pk))
     name = "new name"
@@ -206,7 +206,7 @@ def test_anonymous_owner_can_edit_in_anonymous_owner_mode(
 def test_anonymous_can_edit_in_anonymous_owner_but_public_mode(
     datalayer, client, anonymap, post_data
 ):
-    datalayer.edit_status = DataLayer.ANONYMOUS
+    datalayer.edit_status = DataLayer.OPEN
     datalayer.save()
     url = reverse("datalayer_update", args=(anonymap.pk, datalayer.pk))
     name = "new name"
@@ -221,7 +221,7 @@ def test_anonymous_can_edit_in_anonymous_owner_but_public_mode(
 def test_anonymous_cannot_edit_in_anonymous_owner_mode(
     datalayer, client, anonymap, post_data
 ):
-    datalayer.edit_status = DataLayer.OWNER
+    datalayer.edit_status = DataLayer.RESTRICTED
     datalayer.save()
     url = reverse("datalayer_update", args=(anonymap.pk, datalayer.pk))
     name = "new name"
@@ -231,7 +231,7 @@ def test_anonymous_cannot_edit_in_anonymous_owner_mode(
 
 
 def test_anonymous_cannot_edit_in_owner_mode(datalayer, client, map, post_data):
-    datalayer.edit_status = DataLayer.OWNER
+    datalayer.edit_status = DataLayer.RESTRICTED
     datalayer.save()
     url = reverse("datalayer_update", args=(map.pk, datalayer.pk))
     name = "new name"
@@ -241,7 +241,7 @@ def test_anonymous_cannot_edit_in_owner_mode(datalayer, client, map, post_data):
 
 
 def test_anonymous_can_edit_in_owner_but_public_mode(datalayer, client, map, post_data):
-    datalayer.edit_status = DataLayer.ANONYMOUS
+    datalayer.edit_status = DataLayer.OPEN
     datalayer.save()
     url = reverse("datalayer_update", args=(map.pk, datalayer.pk))
     name = "new name"
@@ -254,7 +254,7 @@ def test_anonymous_can_edit_in_owner_but_public_mode(datalayer, client, map, pos
 
 def test_owner_can_edit_in_owner_mode(datalayer, client, map, post_data):
     client.login(username=map.owner.username, password="123123")
-    datalayer.edit_status = DataLayer.OWNER
+    datalayer.edit_status = DataLayer.RESTRICTED
     datalayer.save()
     url = reverse("datalayer_update", args=(map.pk, datalayer.pk))
     name = "new name"
@@ -267,7 +267,7 @@ def test_owner_can_edit_in_owner_mode(datalayer, client, map, post_data):
 
 def test_editor_can_edit_in_editors_mode(datalayer, client, map, post_data):
     client.login(username=map.owner.username, password="123123")
-    datalayer.edit_status = DataLayer.EDITORS
+    datalayer.edit_status = DataLayer.RESTRICTED
     datalayer.save()
     url = reverse("datalayer_update", args=(map.pk, datalayer.pk))
     name = "new name"

--- a/umap/tests/test_map.py
+++ b/umap/tests/test_map.py
@@ -86,14 +86,6 @@ def test_publicmanager_should_get_only_public_maps(map, user, licence):
     assert private_map not in Map.public.all()
 
 
-def test_can_change_default_edit_status(user, settings):
-    map = MapFactory(owner=user)
-    assert map.edit_status == Map.OWNER
-    settings.UMAP_DEFAULT_EDIT_STATUS = Map.EDITORS
-    map = MapFactory(owner=user)
-    assert map.edit_status == Map.EDITORS
-
-
 def test_can_change_default_share_status(user, settings):
     map = MapFactory(owner=user)
     assert map.share_status == Map.PUBLIC

--- a/umap/views.py
+++ b/umap/views.py
@@ -460,7 +460,7 @@ class MapDetailMixin:
         }
         if getattr(self, "object", None) and self.object.owner:
             properties["edit_statuses"] = [
-                (i, str(label)) for i, label in Map.EDIT_STATUS
+                (i, str(label)) for i, label in DataLayer.EDIT_STATUS
             ]
         else:
             properties["edit_statuses"] = [


### PR DESCRIPTION
At Map level, there is no more distinction between owner and editors, they all share the same rights (but the right to delete the map, but there is no level to control it).

So having this distinction at DataLayer level does not make sense anymore, in my opinion.

This is not retrocompatible, as the change at Map level, but it goes in the sense of permissions management more targeted to real uMap usage while keeping the system simple.

If we agree on this change, I'll add a data migration.
