### PR TITLE
Replace wait_for_database with depends_on and healthcheck.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ version: '3'
 services:
 
   db:
+    healthcheck:
+        test: ["CMD-SHELL", "pg_isready -U postgres"]
+        interval: 2s
     image: postgis/postgis:14-3.3-alpine
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
@@ -10,6 +13,9 @@ services:
       - db:/var/lib/postgresql/data
 
   app:
+    depends_on:
+      db:
+        condition: service_healthy
     image: umap/umap:1.3.2
     ports:
       - "${PORT-8000}:8000"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,24 +3,6 @@ set -eo pipefail
 
 source /venv/bin/activate
 
-# default variables
-: "${SLEEP:=1}"
-: "${TRIES:=60}"
-
-function wait_for_database {(
-  echo "Waiting for database to respond..."
-  tries=0
-  while true; do
-    [[ $tries -lt $TRIES ]] || return
-    (echo "from django.db import connection; connection.connect()" | umap shell) >/dev/null
-    [[ $? -eq 0 ]] && return
-    sleep $SLEEP
-    tries=$((tries + 1))
-  done
-)}
-
-# first wait for the database
-wait_for_database
 # then migrate the database
 umap migrate
 # then collect static files

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,6 +3,8 @@ set -eo pipefail
 
 source /venv/bin/activate
 
+# first wait for the database
+umap wait_for_database
 # then migrate the database
 umap migrate
 # then collect static files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "django-agnocomplete==2.2.0",
   "django-compressor==4.3.1",
   "django-environ==0.10.0",
+  "django-probes==1.7.0",
   "Pillow==9.5.0",
   "psycopg2==2.9.6",
   "requests==2.31.0",

--- a/umap/settings/base.py
+++ b/umap/settings/base.py
@@ -117,6 +117,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.gis',
 
+    'django_probes',
     'umap',
     'compressor',
     'social_django',


### PR DESCRIPTION
I just got started with umap using docker.  Even though the entrypoint has a mechanism to wait for the database, it wasn't waiting.

Docker compose now supports depends_on with a healthcheck.   I feel it's better to use this declarative configuration over imperative bash.

Side note, if this was the only reason "umap shell" exists, then please also close that entry point to remove the attack vector.