### PR TITLE
Ran through the 'Ubuntu from Scratch' procedure using a fresh Ubuntu 22.04.3 LTS VM and took notes on what worked and what didn't.

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -61,7 +61,7 @@ See [Django documentation for MEDIA_ROOT](https://docs.djangoproject.com/en/4.2/
 
 #### SECRET_KEY
 
-Must be defined to something unique and secret. (See https://docs.djangoproject.com/en/4.2/ref/settings/#std:setting-SECRET_KEY if you want to know more.) 
+Must be defined to something unique and secret.
 
 #### SITE_URL
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -61,7 +61,7 @@ See [Django documentation for MEDIA_ROOT](https://docs.djangoproject.com/en/4.2/
 
 #### SECRET_KEY
 
-Must be defined to something unique and secret.
+Must be defined to something unique and secret. (See https://docs.djangoproject.com/en/4.2/ref/settings/#std:setting-SECRET_KEY if you want to know more.) 
 
 #### SITE_URL
 

--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -76,7 +76,7 @@ you will need to run again this last line.*
 
     nano /etc/umap/umap.conf
 
-* update the SECRET_KEY
+* update the [SECRET_KEY](settings.md#secret_key)
 * update the ADMINS list
 
 ## Create the tables

--- a/docs/ubuntu.md
+++ b/docs/ubuntu.md
@@ -6,13 +6,14 @@ You need sudo grants on this server, and it must be connected to Internet.
 
 ## Install system dependencies
 
-    sudo apt install python3 python3-dev python3-venv wget nginx uwsgi uwsgi-plugin-python3 postgresql gcc postgis libpq-dev
+    sudo apt update
+    sudo apt install python3 python3-dev python3-venv virtualenv wget nginx uwsgi uwsgi-plugin-python3 postgresql gcc postgis libpq-dev
 
 *Note: nginx and uwsgi are not required for local development environment*
 
 ## Create deployment directories:
 
-   sudo mkdir -p /etc/umap
+    sudo mkdir -p /etc/umap
 
 *You can change this path, but then remember to adapt the other steps accordingly.*
 
@@ -33,17 +34,17 @@ on the various commands and configuration files if you go with your own.*
 
 ## Create a postgresql user
 
-    sudo -u postgres createuser umap
+    sudo -u postgres -D ~postgres createuser umap
 
 
 ## Create a postgresql database
 
-    sudo -u postgres createdb umap -O umap
+    sudo -u postgres -D ~postgres createdb umap -O umap
 
 
 ## Activate PostGIS extension
 
-    sudo -u postgres psql umap -c "CREATE EXTENSION postgis"
+    sudo -u postgres -D ~postgres psql umap -c "CREATE EXTENSION postgis"
 
 
 ## Login as umap Unix user
@@ -55,8 +56,8 @@ From now on, unless we say differently, the commands are run as `umap` user.
 
 ## Create a virtualenv and activate it
 
-    virtualenv /srv/umap/venv --python=/usr/bin/python3.6
-    source /srv/umap/venv/bin/activate
+    virtualenv /srv/umap/venv --python=/usr/bin/python3.10
+    . /srv/umap/venv/bin/activate
 
 *Note: this activation is not persistent, so if you open a new terminal window,
 you will need to run again this last line.*
@@ -75,12 +76,8 @@ you will need to run again this last line.*
 
     nano /etc/umap/umap.conf
 
-Change the following properties:
-
-```
-STATIC_ROOT = '/srv/umap/var/static'
-MEDIA_ROOT = '/srv/umap/var/data'
-```
+* update the SECRET_KEY
+* update the ADMINS list
 
 ## Create the tables
 


### PR DESCRIPTION
Here's a summary of the changes and why

* added 'apt update' before the install -- only _needed_ on a completely fresh VM, but never hurts

* added an install of the virtualenv package, because it is used later but: do you still need it AND python3-venv? I'm assuming it was done that way for a reason.

* changed indentation on the mkdir so it will format correctly

* added `-D ~postgres` to the commands executed as postgres user because the postgres user does not, by default, have permission to read into real user's home directories (at least in 22.04) and so the commands would error out

* change `source <activate>` to `. activate` because the line `sudo -u umap -i` launches `sh`, not `bash`, and `sh` does not recognize the source command. `.` works in either.

* remove the instructions to change STATIC_ROOT and MEDIA_ROOT because they are already defaulted to those values in the current version sample of local.py

* added a notice to change the SECREY_KEY and ADMINS list just because it seemed like a good idea.

Side note: I have not seen any docs anywhere that explains exactly what the secret Key does, or where it is used. It's used a magic variable in the config file.. ?

I am not currently messing with nginx or wsgi, so I can't comment on those parts.