### PR TITLE
Redirect to canonical when URL contains the ?edit parameter

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -265,9 +265,11 @@ L.U.Map.include({
       if (slug && this.features_index[slug]) this.features_index[slug].view()
       if (L.Util.queryString('edit')) {
         if (this.hasEditMode()) this.enableEdit()
-        // Sometimes users share the ?edit link by mistake, let's redirect
-        // to canonical in this case
-        else window.location = window.location.pathname
+        // Sometimes users share the ?edit link by mistake, let's remove
+        // this search parameter from URL to prevent this
+        const url = new URL(window.location)
+        url.searchParams.delete('edit')
+        history.pushState({}, '', url)
       }
       if (L.Util.queryString('download')) this.download()
     })

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -263,7 +263,12 @@ L.U.Map.include({
     this.onceDataLoaded(function () {
       const slug = L.Util.queryString('feature')
       if (slug && this.features_index[slug]) this.features_index[slug].view()
-      if (L.Util.queryString('edit')) this.enableEdit()
+      if (L.Util.queryString('edit')) {
+        if (this.hasEditMode()) this.enableEdit()
+        // Sometimes users share the ?edit link by mistake, let's redirect
+        // to canonical in this case
+        else window.location = window.location.pathname
+      }
       if (L.Util.queryString('download')) this.download()
     })
 

--- a/umap/tests/integration/test_owned_map.py
+++ b/umap/tests/integration/test_owned_map.py
@@ -94,6 +94,8 @@ def test_owner_permissions_form(map, datalayer, live_server, login):
         ".datalayer-permissions select[name='edit_status'] option:checked"
     )
     expect(option).to_have_text("Inherit")
+    # Should have been removed since page load
+    assert "edit" not in page.url
 
 
 def test_map_update_with_editor(map, live_server, login, user):


### PR DESCRIPTION
We don't want those link to be shared.