### PR TITLE
Set an explicit width to popup large container

### DIFF
--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -1463,11 +1463,13 @@ a.add-datalayer:hover,
 .leaflet-contextmenu-icon {
     display: none;
 }
-.umap-popup-large img,
 .umap-popup-large iframe {
     /* See https://github.com/Leaflet/Leaflet/commit/61d746818b99d362108545c151a27f09d60960ee#commitcomment-6061847 */
     max-width: 100% !important;
     min-width: 500px;
+}
+.umap-popup-large .umap-popup-content {
+    width: 500px;
 }
 .umap-popup-content img {
     max-width: 100%;
@@ -1534,9 +1536,11 @@ a.add-datalayer:hover,
     .umap-permanent-credits-container {
         max-width: 100%;
     }
-    .umap-popup-large img,
     .umap-popup-large iframe {
         min-width: 300px;
+    }
+    .umap-popup-large .umap-popup-content {
+        width: 300px;
     }
 }
 


### PR DESCRIPTION
Until now, the width was computed on the fly by Leaflet, based on the popup content, but this leads to a bunch of issue on image/iframe width.

Before:

![image](https://github.com/umap-project/umap/assets/146023/0590bd1c-df60-4bef-8a65-b78061135d45)


After:

![image](https://github.com/umap-project/umap/assets/146023/8d53b797-444c-4aae-b076-e27187762b8f)


cf https://forum.openstreetmap.fr/t/bugs-divers-relevees-sur-une-umap-absent-sur-une-autre/17254/8