### PR TITLE
Do no try to fit data bounds if bounds are not valid

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -672,11 +672,12 @@ L.U.Map.include({
       this._controls.locate.start()
     } else if (this.options.defaultView === 'data') {
       this.onceDataLoaded(() => {
-        if (!this.hasData()) {
+        const bounds = this.getLayersBounds()
+        if (!this.hasData() || !bounds.isValid()) {
           this._setDefaultCenter()
           return
         }
-        this.fitBounds(this.getLayersBounds())
+        this.fitBounds(bounds)
       })
     } else if (this.options.defaultView === 'latest') {
       this.onceDataLoaded(() => {


### PR DESCRIPTION
This may happen if:
- the map as some layers containing data, but set as not browsable
- any other layer is empty