### PR TITLE
Fix map's title when “dirty star” is present

### DIFF
--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -516,7 +516,7 @@ ul.photon-autocomplete {
 a.map-name:after {
     content:  '\00a0';
     padding-left: 3px;
-    width: 5px;
+    width: 1ch;
     display: inline-block;
 }
 .umap-is-dirty a.map-name:after {


### PR DESCRIPTION
The star indicating a dirty map uses more than 5px (depending on font-size). So the additional star switched from showing the map name to ellipses-overflow in px-implementation.
1ch is the with of the digit '0'.

So the issue in #1308 is not about max-width but also reproducible for very short map names.

Nevertheless max-width of 200px for a.map-name seems a bit restrictive for desktop browsers and could be increased?!

Replaces #1310 