### PR TITLE
First naive version of datalayer grouping

### DIFF
--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -198,6 +198,16 @@ L.Util.greedyTemplate = (str, data, ignore) => {
   )
 }
 
+L.Util.naturalSort = (a, b) => {
+  return a
+    .toString()
+    .toLowerCase()
+    .localeCompare(b.toString().toLowerCase(), L.lang || 'en', {
+      sensitivity: 'base',
+      numeric: true,
+    })
+}
+
 L.Util.sortFeatures = (features, sortKey) => {
   const sortKeys = (sortKey || 'name').split(',')
 
@@ -216,13 +226,7 @@ L.Util.sortFeatures = (features, sortKey) => {
     } else if (!valB) {
       score = 1
     } else {
-      score = valA
-        .toString()
-        .toLowerCase()
-        .localeCompare(valB.toString().toLowerCase(), L.lang || 'en', {
-          sensitivity: 'base',
-          numeric: true,
-        })
+      score = L.Util.naturalSort(valA, valB)
     }
     if (score === 0 && sortKeys[i + 1]) return sort(a, b, i + 1)
     return score * reverse

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -158,6 +158,7 @@ L.U.Map.include({
     // Global storage for retrieving datalayers and features
     this.datalayers = {}
     this.datalayers_index = []
+    this.groups_index = {}
     this.dirty_datalayers = []
     this.features_index = {}
     this.facets = {}
@@ -438,14 +439,27 @@ L.U.Map.include({
 
   indexDatalayers: function () {
     const panes = this.getPane('overlayPane')
-    let pane
     this.datalayers_index = []
-    for (let i = 0; i < panes.children.length; i++) {
+    for (let i = 0, pane, datalayer; i < panes.children.length; i++) {
       pane = panes.children[i]
       if (!pane.dataset || !pane.dataset.id) continue
-      this.datalayers_index.push(this.datalayers[pane.dataset.id])
+      datalayer = this.datalayers[pane.dataset.id]
+      this.datalayers_index.push(datalayer)
     }
+    this.indexGroups()
     this.updateDatalayersControl()
+  },
+
+  indexGroups: function () {
+    this.groups_index = {}
+    this.eachDataLayer(this.indexGroup)
+  },
+
+  indexGroup: function (datalayer) {
+      const group = datalayer.options.group
+      if (!group) return
+      this.groups_index[group] = this.groups_index[group] || []
+      this.groups_index[group].push(L.stamp(datalayer))
   },
 
   ensurePanesOrder: function () {
@@ -1014,14 +1028,14 @@ L.U.Map.include({
 
   eachDataLayer: function (method, context) {
     for (let i = 0; i < this.datalayers_index.length; i++) {
-      method.call(context, this.datalayers_index[i])
+      method.call(context || this, this.datalayers_index[i])
     }
   },
 
   eachDataLayerReverse: function (method, context, filter) {
     for (let i = this.datalayers_index.length - 1; i >= 0; i--) {
       if (filter && !filter.call(context, this.datalayers_index[i])) continue
-      method.call(context, this.datalayers_index[i])
+      method.call(context || this, this.datalayers_index[i])
     }
   },
 

--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -487,6 +487,7 @@ L.U.DataLayer = L.Evented.extend({
       this.map.datalayers[id] = this
       if (L.Util.indexOf(this.map.datalayers_index, this) === -1)
         this.map.datalayers_index.push(this)
+      this.map.indexGroup(this)
     }
     this.map.updateDatalayersControl()
   },
@@ -853,6 +854,7 @@ L.U.DataLayer = L.Evented.extend({
       metadataFields = [
         'options.name',
         'options.description',
+        ['options.group', { handler: 'BlurInput', label: L._('Layer group'), datalist: Object.keys(this.map.groups_index)}],
         ['options.type', { handler: 'LayerTypeChooser', label: L._('Type of layer') }],
         ['options.displayOnLoad', { label: L._('Display on load'), handler: 'Switch' }],
         [
@@ -867,6 +869,7 @@ L.U.DataLayer = L.Evented.extend({
     const title = L.DomUtil.add('h3', '', container, L._('Layer properties'))
     let builder = new L.U.FormBuilder(this, metadataFields, {
       callback: function (e) {
+        this.map.indexGroups()
         this.map.updateDatalayersControl()
         if (e.helper.field === 'options.type') {
           this.resetLayer()

--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -694,6 +694,7 @@ a.map-name:after {
     max-height: 15em;
     overflow-y: auto;
 }
+.layer-group i,
 .search-result-tools i,
 .leaflet-inplace-toolbar a,
 .umap-browse-features i,
@@ -717,6 +718,12 @@ a.map-name:after {
     margin-right: 5px;
     cursor: move;
 }
+.umap-browse-datalayers.grouped li {
+    padding-left: 10px;
+}
+.umap-browse-datalayers.grouped h4 {
+    margin-bottom: 0;
+}
 .leaflet-inplace-toolbar a {
     background-image: url('./img/16-white.svg');
     background-color: #323737!important;
@@ -730,6 +737,7 @@ a.map-name:after {
 .leaflet-control-browse .umap-browse-datalayers .off i {
     cursor: inherit;
 }
+.group-toggle,
 .layer-toggle {
     background-position: -49px -31px;
 }


### PR DESCRIPTION
![image](https://github.com/umap-project/umap/assets/146023/a8ee12e4-e652-4350-8708-23de63a5102e)

A few questions/remarks:

- we are using datalist so groups name have to be written only once and will then appear in autocomplete, but if one wants to reword a group name, they will need to reword it once, but then go to all datalayers of this group to select the new value
- the "toggle all" button does not reflect the current state of the visibility of the group (tricky: all visible, all hidden, or mixed)
- at this stage, datalayers without a group are not displayed any more in the browser, letting users choose either to have a group "Others" or let them hidden, but maybe we want something more automatic
- we do not reflect groups yet in the caption panel, but we should do if this is the direction we want to take
- going this way, we touch the idea of also changing colors and settings for a whole group at once, so that would mean a sort of datalayer hierarchy, but this would open a lot of questions (perms being maybe the tricky one) 
- no integration tests yet as I'm not sure yet it's the way to go