### PR TITLE
Update uwsgi.ini to prevent buffers errors with NGINX reverse proxies

### DIFF
--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -9,3 +9,4 @@ processes = 4
 enable-threads = true
 static-map = /static=/srv/umap/static
 static-map = /uploads=/srv/umap/uploads
+buffer-size = 32768


### PR DESCRIPTION
Prevents issues as described in #1353 