### PR TITLE
switch to grid layout for multiple choice buttons

### DIFF
--- a/umap/static/umap/base.css
+++ b/umap/static/umap/base.css
@@ -342,18 +342,23 @@ input.switch:checked ~ label:before {
 input.switch:checked ~ label:after {
     margin-left: 3em;
 }
-.button-bar {
+.button-bar, .umap-multiplechoice {
     margin-top: 5px;
     text-align: center;
     display: grid;
-    grid-gap: 7px;
     width: 100%
+}
+.button-bar {
+    grid-gap: 7px;
 }
 .button-bar.half {
     grid-template-columns: 1fr 1fr;
 }
-.button-bar.third {
+.button-bar.third, .umap-multiplechoice.by3 {
     grid-template-columns: 1fr 1fr 1fr;
+}
+.umap-multiplechoice.by4 {
+    grid-template-columns: 1fr 1fr 1fr 1fr;
 }
 .button-bar .button {
     display: inline-block;
@@ -365,14 +370,11 @@ input.switch:checked ~ label:after {
     border: 1px solid #374E75;
     cursor: pointer;
     background-color: #c9c9c7;
-    height: 30px;
+    min-height: 30px;
     line-height: 30px;
     text-align: center;
-    width: calc(100% / 3);
+    width: 100%;
     display: inline-block;
-}
-.umap-multiplechoice.by4 label {
-    width: calc(100% / 4);
 }
 .dark .umap-multiplechoice label {
     border: 1px solid black;

--- a/umap/static/umap/base.css
+++ b/umap/static/umap/base.css
@@ -354,7 +354,7 @@ input.switch:checked ~ label:after {
 .button-bar.half {
     grid-template-columns: 1fr 1fr;
 }
-.button-bar.third, .umap-multiplechoice.by3 {
+.umap-multiplechoice.by3 {
     grid-template-columns: 1fr 1fr 1fr;
 }
 .umap-multiplechoice.by4 {


### PR DESCRIPTION
to allow multi-line texts in translations

in svedish and german translation the buttons for "Open link in..." are longer. This results in multiline-buttons that the fixed height cannot handle.

![grafik](https://github.com/umap-project/umap/assets/903453/5b201fff-7926-48bc-ba6e-ae6a298d3f74)


I first thought about shortening translations - but how can one make sure, that every string in every language fits within the buttons? Thus I suggest to switch to the `grid` layout, which is already used by the button-bar. 

The only difference between `.button-bar` and `.umap-multiplechoice` is now the grid-gap.