### PR TITLE
Allow to hide a datalayer from the caption list

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -749,6 +749,7 @@ L.U.Map.include({
     }
     const datalayerContainer = L.DomUtil.create('div', 'datalayer-container', container)
     this.eachVisibleDataLayer((datalayer) => {
+      if (!datalayer.options.inCaption) return
       const p = L.DomUtil.create('p', 'datalayer-legend', datalayerContainer),
         legend = L.DomUtil.create('span', '', p),
         headline = L.DomUtil.create('strong', '', p),

--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -192,6 +192,7 @@ L.U.Layer.Heat = L.HeatLayer.extend({
 L.U.DataLayer = L.Evented.extend({
   options: {
     displayOnLoad: true,
+    inCaption: true,
     browsable: true,
     editMode: 'advanced',
   },
@@ -861,6 +862,13 @@ L.U.DataLayer = L.Evented.extend({
             label: L._('Data is browsable'),
             handler: 'Switch',
             helpEntries: 'browsable',
+          },
+        ],
+        [
+          'options.inCaption',
+          {
+            label: L._('Show this layer in the caption'),
+            handler: 'Switch',
           },
         ],
       ]

--- a/umap/tests/base.py
+++ b/umap/tests/base.py
@@ -1,4 +1,5 @@
 import json
+import copy
 
 import factory
 from django.contrib.auth import get_user_model
@@ -102,13 +103,16 @@ class DataLayerFactory(factory.django.DjangoModelFactory):
     name = "test datalayer"
     description = "test description"
     display_on_load = True
-    settings = {"displayOnLoad": True, "browsable": True, "name": name}
+    settings = factory.Dict({"displayOnLoad": True, "browsable": True, "name": name})
 
     @classmethod
     def _adjust_kwargs(cls, **kwargs):
-        data = kwargs.pop("data", DATALAYER_DATA).copy()
+        data = kwargs.pop("data", copy.deepcopy(DATALAYER_DATA))
         kwargs["settings"]["name"] = kwargs["name"]
-        data["_umap_options"] = kwargs["settings"]
+        data["_umap_options"] = {
+            **DataLayerFactory.settings._defaults,
+            **kwargs["settings"],
+        }
         kwargs["geojson"] = ContentFile(json.dumps(data), "foo.json")
         return kwargs
 


### PR DESCRIPTION
In some situations, we don't want all datalayers to be displayed in the caption list, for example because the layer only contains "non meaningful" data: aesthetics one, or technical, or administrative…

Not sure about the property name…