### PR TITLE
Fix map reference in DataLayersControl

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -514,7 +514,7 @@ L.U.DataLayersControl = L.Control.extend({
   update: function () {
     if (this._datalayers_container && this._map) {
       this._datalayers_container.innerHTML = ''
-      this._map.eachDataLayerReverse(function (datalayer) {
+      this.map.eachDataLayerReverse(function (datalayer) {
         this.addDataLayer(this._datalayers_container, datalayer)
       }, this)
     }
@@ -525,7 +525,7 @@ L.U.DataLayersControl = L.Control.extend({
   },
 
   collapse: function () {
-    if (this._map.options.datalayersControl === 'expanded') return
+    if (this.map.options.datalayersControl === 'expanded') return
     L.DomUtil.removeClass(this._container, 'expanded')
   },
 


### PR DESCRIPTION
This would create an error when DataLayersControl is not added to the map, but the mouseenter/leave event would still be active through the datalayers list