### PR TITLE
Add back HeatLayer._map reference check

### DIFF
--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -374,6 +374,14 @@ L.U.Layer.Heat = L.HeatLayer.extend({
     this._updateOptions()
   },
 
+  redraw: function () {
+    // setlalngs call _redraw through setAnimFrame, thus async, so this
+    // can ends with race condition if we remove the layer very faslty after.
+    // TODO: PR in upstream Leaflet.heat
+    if (!this._map) return
+    L.HeatLayer.prototype.redraw.call(this)
+  },
+
   _redraw: function () {
     // Import patch from https://github.com/Leaflet/Leaflet.heat/pull/78
     // Remove me when this get merged and released.


### PR DESCRIPTION
In some situation, the property is undefined, given the call is async, and we can add/remove the layer during the async stack