### PR TITLE
Hide the next icon in buttons’ sprites

### DIFF
--- a/umap/static/umap/base.css
+++ b/umap/static/umap/base.css
@@ -450,7 +450,7 @@ i.info {
 .umap-clone:before, .umap-edit:before, .umap-download:before,
 .umap-to-polyline:before {
     background-repeat: no-repeat;
-    text-indent: 38px;
+    text-indent: 36px;
     height: 24px;
     line-height: 24px;
     display: inline-block;


### PR DESCRIPTION
This is what is currently visible (1px of the next icon):
<img width="143" alt="Capture d’écran, le 2023-10-16 à 15 17 30" src="https://github.com/umap-project/umap/assets/3556/06da8339-0c55-4924-8e92-7d0c45844d2c">

For instance if I put 44px, it's more visible:
<img width="158" alt="Capture d’écran, le 2023-10-16 à 15 17 45" src="https://github.com/umap-project/umap/assets/3556/5f3e8bb5-1476-4ab4-9d17-ecf19ace3523">

Now this is the fix:
<img width="140" alt="Capture d’écran, le 2023-10-16 à 15 17 52" src="https://github.com/umap-project/umap/assets/3556/3a6a9a0a-09f3-475b-8ecf-3d52cdacdf81">

There is no small fix, hey!