### PR TITLE
Fix max not loading when defaultView=latest and datalayer has no data

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -697,6 +697,7 @@ L.U.Map.include({
         const datalayer = this.defaultDataLayer(),
           feature = datalayer.getFeatureByIndex(-1)
         if (feature) feature.zoomTo()
+        else this._setDefaultCenter()
       })
     } else {
       this._setDefaultCenter()


### PR DESCRIPTION
When the default datalayer has no data, we need a fallback

fix #1374