### PR TITLE
Fix filter data crashing when data contains non string values

### DIFF
--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -478,8 +478,9 @@ L.U.FeatureMixin = {
 
   matchFilter: function (filter, keys) {
     filter = filter.toLowerCase()
-    for (let i = 0; i < keys.length; i++) {
-      if ((this.properties[keys[i]] || '').toLowerCase().indexOf(filter) !== -1)
+    for (let i = 0, value; i < keys.length; i++) {
+      value = (this.properties[keys[i]] || '') + ''
+      if (value.toLowerCase().indexOf(filter) !== -1)
         return true
     }
     return false


### PR DESCRIPTION
It may happen when data comes from an import.

fix #1377