### PR TITLE
Keep only non graphic props in default properties, to prevent useless redraw

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -1299,7 +1299,7 @@ L.U.Map.include({
 
     builder = new L.U.FormBuilder(this, shapeOptions, {
       callback: function (e) {
-        this.eachDataLayer((datalayer) => {
+        this.eachVisibleDataLayer((datalayer) => {
           datalayer.redraw()
         })
       },
@@ -1386,10 +1386,11 @@ L.U.Map.include({
         if (
           e.helper.field === 'options.popupTemplate' ||
           e.helper.field === 'options.popupContentTemplate' ||
-          e.helper.field === 'options.popupShape'
+          e.helper.field === 'options.popupShape' ||
+          e.helper.field === 'options.outlinkTarget'
         )
           return
-        this.eachDataLayer((datalayer) => {
+        this.eachVisibleDataLayer((datalayer) => {
           datalayer.redraw()
         })
       },

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -1293,6 +1293,8 @@ L.U.Map.include({
       'options.fill',
       'options.fillColor',
       'options.fillOpacity',
+      'options.smoothFactor',
+      'options.dashArray',
     ]
 
     builder = new L.U.FormBuilder(this, shapeOptions, {
@@ -1311,8 +1313,6 @@ L.U.Map.include({
 
   _editDefaultProperties: function (container) {
     const optionsFields = [
-      'options.smoothFactor',
-      'options.dashArray',
       'options.zoomTo',
       ['options.easing', { handler: 'Switch', label: L._('Animated transitions') }],
       'options.labelKey',
@@ -1359,10 +1359,9 @@ L.U.Map.include({
     builder = new L.U.FormBuilder(this, optionsFields, {
       callback: function (e) {
         this.initCaptionBar()
-        this.eachDataLayer((datalayer) => {
-          if (e.helper.field === 'options.sortKey') datalayer.reindex()
-          datalayer.redraw()
-        })
+        if (e.helper.field === 'options.sortKey') {
+          this.eachDataLayer((datalayer) => datalayer.reindex())
+        }
       },
     })
     const defaultProperties = L.DomUtil.createFieldset(


### PR DESCRIPTION
Keep together "shape" related properties, so in the default properties we don't need to do a redraw.