### PR TITLE
Round range step to 1 digit

### DIFF
--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -856,7 +856,7 @@ L.FormBuilder.Range = L.FormBuilder.FloatInput.extend({
     this.input.setAttribute('list', datalist.id)
     let options = ''
     const step = this.options.step || 1,
-      digits = step < 1 ? 2 : 0
+      digits = step < 1 ? 1 : 0
     for (let i = this.options.min; i <= this.options.max; i += this.options.step) {
       options += `<option value="${i.toFixed(digits)}" label="${i.toFixed(digits)}"></option>`
     }


### PR DESCRIPTION
Before:
![Screenshot from 2023-10-26 22-37-56](https://github.com/umap-project/umap/assets/146023/0c409557-1b99-404b-b084-373cb0ee8c0e)

After:
![Screenshot from 2023-10-26 22-37-15](https://github.com/umap-project/umap/assets/146023/ae8bdbba-3735-4582-870f-05c41bf7232f)

I don't think we really have cases where we'd need 2 digits rounding.