### PR TITLE
Increase maxZoomLimit to 24

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -14,7 +14,7 @@ L.Map.mergeOptions({
   default_popupContentTemplate: '# {name}\n{description}',
   default_interactive: true,
   default_labelDirection: 'auto',
-  maxZoomLimit: 20,
+  maxZoomLimit: 24,
   attributionControl: false,
   editMode: 'advanced',
   embedControl: true,


### PR DESCRIPTION
Even if this limit is not a hard limit, just a warning, we now have been proven some maps using custom backgrounds use zooms greater than 20.

Eg. this maps which allows zoom until 23:

https://umap.openstreetmap.fr/fr/map/cimetiere-asnieres-la-giraud_716488