### PR TITLE
Fix variable declared globally by mistake

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -397,7 +397,11 @@ L.U.Map.include({
 
   loadDatalayers: function (force) {
     force = force || L.Util.queryString('download') // In case we are in download mode, let's go strait to loading all data
-    let toload = (dataToload = total = this.datalayers_index.length)
+    const total = this.datalayers_index.length
+    // toload => datalayer metadata remaining to load (synchronous)
+    // dataToload => datalayer data remaining to load (asynchronous)
+    let toload = total,
+      dataToload = total
     let datalayer
     const loaded = () => {
       this.datalayersLoaded = true


### PR DESCRIPTION
This can have an impact in map listing, because dataToload will be shared.