### PR TITLE
Fix race condition with cluster layer

### DIFF
--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -60,6 +60,16 @@ L.U.Layer.Cluster = L.MarkerClusterGroup.extend({
     this._layers = []
   },
 
+  onRemove: function (map) {
+    // In some situation, the onRemove is called before the layer is really
+    // added to the map: basically when combining a defaultView=data + max/minZoom
+    // and loading the map at a zoom outside of that zoom range.
+    // FIXME: move this upstream (_unbindEvents should accept a map parameter
+    // instead of relying on this._map)
+    this._map = map
+    return L.MarkerClusterGroup.prototype.onRemove.call(this, map)
+  },
+
   addLayer: function (layer) {
     this._layers.push(layer)
     return L.MarkerClusterGroup.prototype.addLayer.call(this, layer)


### PR DESCRIPTION
This occurs when the cluster layer has a min/maxZoom defined, the map is loaded inside this zoom range BUT the defaultView=data, and would immediately change the current zoom to a value outside this range.

In this case, the datalayer is added to the map, then the data is requested, then the map view is recomputed with the full data bounds.

There may be a better fix on our side, but given there is async in the middle, it can be time consuming and can add complexity (with more events and listeners) to properly make it work.