### PR TITLE
Fix wrong css selector for umap-alert-container elements

### DIFF
--- a/umap/static/umap/base.css
+++ b/umap/static/umap/base.css
@@ -736,24 +736,24 @@ input:invalid {
     visibility: visible;
     top: 23px;
 }
-.umap-alert .umap-action {
+.umap-alert-container .umap-action {
     margin-left: 10px;
     background-color: #fff;
     color: #000;
     padding: 5px;
     border-radius: 4px;
 }
-.umap-alert .umap-action:hover {
+.umap-alert-container .umap-action:hover {
     color: #000;
 }
-.umap-alert .error .umap-action {
+.umap-alert-container .error .umap-action {
     background-color: #666;
     color: #eee;
 }
-.umap-alert .error .umap-action:hover {
+.umap-alert-container .error .umap-action:hover {
     color: #fff;
 }
-.umap-alert input {
+.umap-alert-container input {
     padding: 5px;
     border-radius: 4px;
     width: 100%;


### PR DESCRIPTION
`umap-alert` is set on the body to show/hide the alert container, so it's to wide:

![image](https://github.com/umap-project/umap/assets/146023/012945df-9f11-4412-bb83-c3ec3572f965)


fix #1398