### PR TITLE
Improve buttons’ contrasts on the homepage #a11y

### DIFF
--- a/umap/static/umap/content.css
+++ b/umap/static/umap/content.css
@@ -175,14 +175,14 @@ body.content #umap-ui-container {
 input[type="submit"],
 .button {
     background-color: #79c1c0;
-    color: #eeeeec;
+    color: #323737;
 }
 .wrapper input[type="submit"]:hover {
     background-color: #689191;
 }
 .wrapper .neutral, .wrapper input[type="submit"].neutral {
     background-color: #ddd;
-    color: #666;
+    color: #323737;
 }
 .wrapper.somber {
     background-color: #2E3641;

--- a/umap/static/umap/nav.css
+++ b/umap/static/umap/nav.css
@@ -63,7 +63,6 @@ footer .i18n_switch {
 }
 .umap-nav .button,
 .umap-nav .button:hover {
-    color: #fff;
     text-decoration: none;
     min-width: 150px;
 }


### PR DESCRIPTION
Before:
<img width="1225" alt="Capture d’écran, le 2023-11-14 à 11 59 44" src="https://github.com/umap-project/umap/assets/3556/d881bea9-f7c7-4ecd-99a5-1f9ae5ff0b1a">

After:
<img width="1216" alt="Capture d’écran, le 2023-11-14 à 11 59 24" src="https://github.com/umap-project/umap/assets/3556/99c7c199-a06a-484f-8fef-7d4cde17ef36">

This time, baked by @Aurelie-Jallut 😇 