### PR TITLE
fix icons

### DIFF
--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -850,13 +850,13 @@ ul.photon-autocomplete {
     background-position: -119px -48px;
 }
 .umap-delete-vertex {
-    background-position: -119px -22px;
+    background-position: -119px -94px;
 }
 .umap-continue-line {
     background-position: -96px 1px;
 }
 .umap-split-line {
-    background-position: -120px 1px;
+    background-position: -119px -22px;
 }
 .umap-extract-shape-from-multi{
     background-position: -119px 2px;


### PR DESCRIPTION
probably the icons moved accidentally in c8065fb29e67ae579673f0666175adbf8e4116fd?

Current master (left icon is delete-vertex, right icon is split-line):
![Master](https://github.com/umap-project/umap/assets/903453/3ae01bc0-d336-47ee-a943-d12067e44978)

Suggested Change (that's what it looked like in the past and would intuitively fit to the function):
![Suggested by this PR](https://github.com/umap-project/umap/assets/903453/8b20f9c4-2b17-48e3-a472-8d8a82fa30de)

Was the commit c8065fb29e67ae579673f0666175adbf8e4116fd that introduced the change meant to re-order the symbols? Or accidentally replaced them with different icons?
