### PR TITLE
Restore style of "restore version button"

### DIFF
--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -1347,13 +1347,14 @@ L.U.DataLayer = L.Evented.extend({
       const date = new Date(parseInt(data.at, 10))
       const content = `${date.toLocaleString(L.lang)} (${parseInt(data.size) / 1000}Kb)`
       const el = L.DomUtil.create('div', 'umap-datalayer-version', versionsContainer)
-      const a = L.DomUtil.createButton(
+      const button = L.DomUtil.createButton(
         '',
         el,
-        L._('Restore this version'),
+        '',
         () => this.restore(data.name),
         this
       )
+      button.title = L._('Restore this version')
       L.DomUtil.add('span', '', el, content)
     }
 

--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -724,18 +724,14 @@ ul.photon-autocomplete {
     padding: 5px 0;
     border-bottom: 1px solid #202425;
 }
-.umap-datalayer-version a {
+.umap-datalayer-version button {
     display: inline-block;
-    width: 20px;
-    height: 20px;
-    margin-left: 5px;
-    background-position: -123px -75px;
+    width: 24px;
+    min-height: 24px;
+    background-position: -122px -73px;
     background-repeat: no-repeat;
     background-image: url('./img/16-white.svg');
-    vertical-align: middle;
-    margin-right: 5px;
-    border: 1px solid #202425;
-    background-color: #2c3233;
+    margin-right: 10px;
 }
 
 


### PR DESCRIPTION
I guess we forgot this when switching from `a` to `button`

![Screenshot from 2023-11-23 10-50-19](https://github.com/umap-project/umap/assets/146023/34d4e84b-7ced-4326-a0d4-8f611cc20892)

![image](https://github.com/umap-project/umap/assets/146023/98bd99ae-be28-4d66-b1f3-96501b7675de)
