### PR TITLE
Use step=any by default for FloatInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "leaflet-contextmenu": "^1.4.0",
     "leaflet-editable": "^1.2.0",
     "leaflet-editinosm": "0.2.3",
-    "leaflet-formbuilder": "0.2.7",
+    "leaflet-formbuilder": "0.2.9",
     "leaflet-fullscreen": "1.0.2",
     "leaflet-hash": "0.2.1",
     "leaflet-i18n": "0.3.3",

--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -680,8 +680,8 @@ L.U.Marker = L.Marker.extend({
   appendEditFieldsets: function (container) {
     L.U.FeatureMixin.appendEditFieldsets.call(this, container)
     const coordinatesOptions = [
-      ['_latlng.lat', { handler: 'FloatInput', label: L._('Latitude'), step: 'any' }],
-      ['_latlng.lng', { handler: 'FloatInput', label: L._('Longitude'), step: 'any' }],
+      ['_latlng.lat', { handler: 'FloatInput', label: L._('Latitude') }],
+      ['_latlng.lng', { handler: 'FloatInput', label: L._('Longitude') }],
     ]
     const builder = new L.U.FormBuilder(this, coordinatesOptions, {
       callback: function () {


### PR DESCRIPTION
This is fixed in Leaflet.FormBuilder itself.

Spotted here yesterday:

![Screenshot from 2023-11-22 17-58-12](https://github.com/umap-project/umap/assets/146023/62dbdcc7-ddf8-447d-a4d3-9c303bd4d74e)
