### PR TITLE
Restore missing buttons in caption bar

### DIFF
--- a/umap/static/umap/base.css
+++ b/umap/static/umap/base.css
@@ -202,6 +202,8 @@ button.flat,
     padding: 0;
     text-align: left;
     min-height: inherit;
+    width: initial;
+    display: initial;
     text-decoration: underline;
 }
 .help-text, .helptext {

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -1744,16 +1744,16 @@ L.U.Map.include({
     this.permissions.addOwnerLink('span', container)
     if (this.options.captionMenus) {
       L.DomUtil.createButton(
-        'umap-about-link',
+        'umap-about-link flat',
         container,
-        ` — ${L._('About')}`,
+        L._('About'),
         this.displayCaption,
         this
       )
       L.DomUtil.createButton(
-        'umap-open-browser-link',
+        'umap-open-browser-link flat',
         container,
-        ` | ${L._('Browse data')}`,
+        L._('Browse data'),
         this.openBrowser,
         this
       )

--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -600,6 +600,13 @@ ul.photon-autocomplete {
 .umap-main-edit-toolbox h3 {
     display: inline;
 }
+.umap-caption-bar button {
+    margin-left: 10px;
+}
+.umap-caption-bar button + button:before {
+    content: '|';
+    padding-right: 10px;
+}
 .umap-main-edit-toolbox .umap-user {
     color: #fff;
 }

--- a/umap/tests/base.py
+++ b/umap/tests/base.py
@@ -124,6 +124,7 @@ class DataLayerFactory(factory.django.DjangoModelFactory):
                 **DataLayerFactory.settings._defaults,
                 **kwargs["settings"],
             }
+        data.setdefault("_umap_options", {})
         data["_umap_options"]["name"] = kwargs["name"]
         kwargs["geojson"] = ContentFile(json.dumps(data), "foo.json")
         return kwargs

--- a/umap/tests/integration/test_slideshow.py
+++ b/umap/tests/integration/test_slideshow.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import expect
+from django.core.files.base import ContentFile
+
+from umap.models import Map, Pictogram
+
+from ..base import DataLayerFactory
+
+pytestmark = pytest.mark.django_db
+
+
+DATALAYER_DATA = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [13.6, 48.5],
+            },
+            "properties": {"name": "1st Point"},
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [13.7, 48.4],
+            },
+            "properties": {"name": "2d Point"},
+        },
+        {
+            "type": "Feature",
+            "geometry": {
+                "type": "Point",
+                "coordinates": [13.5, 48.6],
+            },
+            "properties": {"name": "3d Point"},
+        },
+    ],
+}
+
+
+def test_can_use_slideshow_manually(map, live_server, page):
+    map.settings["properties"]["slideshow"] = {"active": True, "delay": 5000}
+    map.save()
+    DataLayerFactory(map=map, data=DATALAYER_DATA)
+    page.goto(f"{live_server.url}{map.get_absolute_url()}")
+    first_point = page.get_by_text("1st Point")
+    second_point = page.get_by_text("2d Point")
+    third_point = page.get_by_text("3d Point")
+    expect(first_point).to_be_hidden()
+    expect(second_point).to_be_hidden()
+    expect(third_point).to_be_hidden()
+    next_ = page.get_by_title("Zoom to the next")
+    expect(next_).to_be_visible()
+    next_.click()
+    expect(first_point).to_be_visible()
+    next_.click()
+    expect(first_point).to_be_hidden()
+    expect(second_point).to_be_visible()
+    next_.click()
+    expect(first_point).to_be_hidden()
+    expect(second_point).to_be_hidden()
+    expect(third_point).to_be_visible()
+    next_.click()
+    expect(first_point).to_be_visible()
+    expect(second_point).to_be_hidden()
+    expect(third_point).to_be_hidden()


### PR DESCRIPTION
Those button, being width: 100% and display: block were not displayed AND were pushing out also the slideshow buttons.

Before:
![image](https://github.com/umap-project/umap/assets/146023/b0bdfa05-a608-4425-8ca9-df49fddab643)

After:

![image](https://github.com/umap-project/umap/assets/146023/94f4e8e1-a9cc-4379-aa7e-90696071ceb0)
