### PR TITLE
Reset increasing icon text size

### DIFF
--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -1307,7 +1307,6 @@ a.add-datalayer:hover,
     vertical-align: middle;
     color: white;
     font-weight: bold;
-    font-size: 1.2rem;
 }
 .umap-circle-icon {
     border: 1px solid white;


### PR DESCRIPTION
There are some usage with 5 chars that do not fit anymore. Let's reset for now and maybe introduce later a way for the user to configure the size.

### In current master:
![Screenshot from 2023-11-26 17-18-42](https://github.com/umap-project/umap/assets/146023/a3d1c103-6f08-44a5-b19e-b883042e37f8)

### With the reset in this PR:
![Screenshot from 2023-11-26 17-18-31](https://github.com/umap-project/umap/assets/146023/4630b210-a053-4400-8ba0-674ff30d78c9)

See also https://lists.openstreetmap.org/pipermail/umap/2023-November/000545.html
