### PR TITLE
(WIP) Add Bubbles layer type

### DIFF
--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -381,6 +381,7 @@ L.FormBuilder.LayerTypeChooser = L.FormBuilder.Select.extend({
     ['Cluster', L._('Clustered')],
     ['Heat', L._('Heatmap')],
     ['Choropleth', L._('Choropleth')],
+    ['Bubble', L._('Bubbles')],
   ],
 })
 


### PR DESCRIPTION
fix #1399

This is a very first look. But it's not as simple as I thought, because:
- as for a heatmap, we need a special representation (each feature should be a circle, not a normal icon nor a polygon)
- as for a choropleth, we want to dynamically take control over the rendering (we need all the features to be able to compute the bubbles sizes)
- as for a normal layer, we want all the features to react to interaction, specifically click to open a popup, but also tooltip, highlight (?), etc.

In this first implementation, I've created a new type of layer, that creates a CircleMarker for each feature, but doing so we lose all the interactions. I've tried to set a sort of proxy so that a click on the circle will fire a click on the feature, but as this feature is actually not on the map, this does not work naturally.
Also, at this point, the styling is only done once, so editing layer's style will not be updated live in the map.

A few more thinking is needed, mainly to decide how to handle the circle: should it be a "proxy layer" as now, or should we try to transform a feature on the fly (make sure it is a marker of type circle, but as for now our circle are html, not svg…), and in this case, should we magically handle polygons and polylines (taking their center), or only markers (which could be easier, and possibly enough) ?

![image](https://github.com/umap-project/umap/assets/146023/8bb9ccf9-d6cc-4138-bb3c-1d25e5f4eec2)
