### PR TITLE
Allow to control the `interactive` option from the layer

### DIFF
--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -642,7 +642,7 @@ L.U.Help = L.Class.extend({
   facetKey: L._(
     'Comma separated list of properties to use for facet search (eg.: mykey,otherkey). To control label, add it after a | (eg.: mykey|My Key,otherkey|Other Key)'
   ),
-  interactive: L._('If false, the polygon will act as a part of the underlying map.'),
+  interactive: L._('If false, the polygon or line will act as a part of the underlying map.'),
   outlink: L._('Define link to open in a new window on polygon click.'),
   dynamicRemoteData: L._('Fetch data each time map view changes.'),
   proxyRemoteData: L._("To use if remote server doesn't allow cross domain (slower)"),

--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -1132,18 +1132,9 @@ L.U.Polygon = L.Polygon.extend({
   },
 
   getInteractionOptions: function () {
-    const options = [
-      [
-        'properties._umap_options.interactive',
-        {
-          handler: 'Switch',
-          label: L._('Allow interactions'),
-          helpEntries: 'interactive',
-          inheritable: true,
-        },
-      ],
-    ]
-    return options.concat(L.U.FeatureMixin.getInteractionOptions())
+    const options = L.U.FeatureMixin.getInteractionOptions()
+    options.push('properties._umap_options.interactive')
+    return options
   },
 
   getMeasure: function (shape) {

--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -1255,6 +1255,12 @@ L.U.FormBuilder = L.FormBuilder.extend({
       helpText: L._('Optional.'),
     },
     toZoom: { handler: 'IntInput', label: L._('To zoom'), helpText: L._('Optional.') },
+    interactive: {
+      handler: 'Switch',
+      label: L._('Allow interactions'),
+      helpEntries: 'interactive',
+      inheritable: true,
+    },
   },
 
   initialize: function (obj, fields, options) {

--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -1239,6 +1239,7 @@ L.U.DataLayer = L.Evented.extend({
       'options.labelDirection',
       'options.labelInteractive',
       'options.outlinkTarget',
+      'options.interactive',
     ]
     builder = new L.U.FormBuilder(this, popupFields, { callback: redrawCallback })
     const popupFieldset = L.DomUtil.createFieldset(


### PR DESCRIPTION
This flag deactivate all interactions for a path. It can be useful when some polygon is used to delimitate an area on the map, but when we don't want this area to be clickable.

I've a case where I've many of those polygons in a given map, and they are imported, so I don't want to go one by one to deactivate it.

As a side effect, this option will also be available for lines.