### PR TITLE
fix: no data in facet filters when set as default panel

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -937,7 +937,7 @@ L.U.Map.include({
   },
 
   openFacet: function () {
-    this.onceDatalayersLoaded(function () {
+    this.onceDataLoaded(function () {
       this._openFacet()
     })
   },


### PR DESCRIPTION
When facet search is set as the default panel, if using remote data, no filter data was appearing in the panel.