### PR TITLE
[chore] fix docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 # Force rtfd to use a recent version of mkdocs
-mkdocs==1.4.2
-pymdown-extensions==10.1
+mkdocs==1.5.3
+pymdown-extensions==10.4
+mkdocs-material==9.4.14


### PR DESCRIPTION
I didn't catch that docs has a separated requirements.txt file for readthedocs.