### PR TITLE
Make sure DataLayer._dataloaded is set only once all data is imported

### DIFF
--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -665,7 +665,6 @@ L.U.DataLayer = L.Evented.extend({
         this.backupOptions()
         this.fire('loaded')
         this._loading = false
-        this._dataloaded = true
       },
       context: this,
     })
@@ -674,6 +673,7 @@ L.U.DataLayer = L.Evented.extend({
   fromGeoJSON: function (geojson) {
     this.addData(geojson)
     this._geojson = geojson
+    this._dataloaded = true
     this.fire('dataloaded')
     this.fire('datachanged')
   },
@@ -730,7 +730,6 @@ L.U.DataLayer = L.Evented.extend({
       verb: 'GET',
       callback: (raw) => {
         this.clear()
-        this._dataloaded = true
         this.rawToGeoJSON(raw, this.options.remoteData.format, (geojson) =>
           this.fromGeoJSON(geojson)
         )


### PR DESCRIPTION
When DataLayer._dataloaded is set, DataLayer.addLayer will send 'datachanged' event (for once for each feature). When the data browser panel is open, the browser is listening to 'datachanged' to rebuild itself.

Not sure this is the real final fix, but that may need more refactoring, so I think this approach is already a better situation than the current.

fix #1457