### PR TITLE
Do not call AttributionControl._update for removed tile layer

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -1246,8 +1246,10 @@ L.U.AttributionControl = L.Control.Attribution.extend({
   },
 
   _update: function () {
+    // Layer is no more on the map
+    if (!this._map) return
     L.Control.Attribution.prototype._update.call(this)
-    // Use our how container, so we can hide/show on small screens
+    // Use our own container, so we can hide/show on small screens
     const credits = this._container.innerHTML
     this._container.innerHTML = ''
     const container = L.DomUtil.add(


### PR DESCRIPTION
It fails on this._map being undefined, and it's useless.