### PR TITLE
Use real tile URL in tests

### DIFF
--- a/umap/tests/base.py
+++ b/umap/tests/base.py
@@ -81,7 +81,7 @@ class MapFactory(factory.django.DjangoModelFactory):
                     "attribution": "\xa9 OSM Contributors",
                     "maxZoom": 18,
                     "minZoom": 0,
-                    "url_template": "http://{s}.osm.fr/{z}/{x}/{y}.png",
+                    "url_template": "https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png",
                 },
                 "tilelayersControl": True,
                 "zoom": 7,

--- a/umap/tests/integration/test_export_map.py
+++ b/umap/tests/integration/test_export_map.py
@@ -61,7 +61,7 @@ def test_umap_export(map, live_server, datalayer, page):
                 "attribution": "© OSM Contributors",
                 "maxZoom": 18,
                 "minZoom": 0,
-                "url_template": "http://{s}.osm.fr/{z}/{x}/{y}.png",
+                "url_template": "https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png",
             },
             "tilelayersControl": True,
             "zoom": 7,

--- a/umap/tests/test_map_views.py
+++ b/umap/tests/test_map_views.py
@@ -624,7 +624,7 @@ def test_download(client, map, datalayer):
             "attribution": "© OSM Contributors",
             "maxZoom": 18,
             "minZoom": 0,
-            "url_template": "http://{s}.osm.fr/{z}/{x}/{y}.png",
+            "url_template": "https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png",
         },
         "tilelayersControl": True,
         "zoom": 7,


### PR DESCRIPTION
It's easier to debug integration tests screenshots (otherwise background is only grey).