### PR TITLE
Fix toolbox overflow with facets’ search

### DIFF
--- a/umap/static/umap/base.css
+++ b/umap/static/umap/base.css
@@ -698,6 +698,11 @@ input[type=hidden].blur + [type="button"] {
 #umap-ui-container .toolbox {
     padding: 5px 10px;
     overflow: hidden;
+    display: flex;
+    flex-direction: row-reverse;
+    font-size: 10px;
+    justify-content: flex-start;
+    gap: 5px;
 }
 #umap-ui-container .toolbox li {
     color: #2e3436;
@@ -720,10 +725,6 @@ input[type=hidden].blur + [type="button"] {
 #umap-ui-container.dark .toolbox li:hover {
     color: #eeeeec;
     background-color: #353c3e;
-}
-#umap-ui-container .toolbox li + li {
-    margin-right: 5px;
-    margin-left: 5px;
 }
 .dark input, .dark textarea {
     background-color: #232729;


### PR DESCRIPTION
Before:

<img width="393" alt="Capture d’écran, le 2023-12-14 à 17 03 08" src="https://github.com/umap-project/umap/assets/3556/75346ed7-a5e8-480b-be6c-38ea6dbc24b6">

After:

<img width="415" alt="Capture d’écran, le 2023-12-14 à 17 02 55" src="https://github.com/umap-project/umap/assets/3556/7bb3b7d4-a124-4fe7-8da6-6d6554a60be0">

