### PR TITLE
build: Update makefile testjs to open the browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .DEFAULT_GOAL := help
 
+JS_TEST_URL := http://localhost:8001/umap/static/umap/test/index.html
+
 .PHONY: install
 install: ## Install the dependencies
 	python3 -m pip install --upgrade pip
@@ -74,7 +76,19 @@ vendors:
 installjs:
 	npm install
 testjs: node_modules
-	@echo "See the tests at http://localhost:8001/umap/static/umap/test/" && python -m http.server 8001
+	@{ \
+		trap 'kill $$PID; exit' INT; \
+		python -m http.server 8001 & \
+		PID=$$!; \
+		sleep 1; \
+		echo "Opening $(JS_TEST_URL)"; \
+		if command -v python -m webbrowser > /dev/null 2>&1; then \
+			python -m webbrowser "$(JS_TEST_URL)"; \
+		else \
+			echo "Please open $(JS_TEST_URL) in your web browser"; \
+		fi; \
+		wait $$PID; \
+	}
 tx_push:
 	tx push -s
 tx_pull:

--- a/umap/models.py
+++ b/umap/models.py
@@ -16,7 +16,7 @@ from .managers import PublicManager
 # Did not find a clean way to do this in Django
 # - creating a Proxy model would mean replacing get_user_model by this proxy model
 #   in every template
-# - extending User model woulc mean a non trivial migration
+# - extending User model would mean a non trivial migration
 def display_name(self):
     return settings.USER_DISPLAY_NAME.format(**self.__dict__)
 


### PR DESCRIPTION
Following the discussion on #1471, here are proposed changes to the `Makefile`.

- Runs a subprocess, and setup a trap to ensure ctrl+c can stop the server
- Uses [`python -m webbrowser`](https://docs.python.org/3/library/webbrowser.html) to open a new tab (cross compatible)