### PR TITLE
fix: accept long floats for latitude and longitude

### DIFF
--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -680,8 +680,26 @@ L.U.Marker = L.Marker.extend({
   appendEditFieldsets: function (container) {
     L.U.FeatureMixin.appendEditFieldsets.call(this, container)
     const coordinatesOptions = [
-      ['_latlng.lat', { handler: 'FloatInput', label: L._('Latitude') }],
-      ['_latlng.lng', { handler: 'FloatInput', label: L._('Longitude') }],
+      [
+        '_latlng.lat',
+        {
+          handler: 'FloatInput',
+          label: L._('Latitude'),
+          step: 'any',
+          min: -90,
+          max: 90,
+        },
+      ],
+      [
+        '_latlng.lng',
+        {
+          handler: 'FloatInput',
+          label: L._('Longitude'),
+          step: 'any',
+          min: -180,
+          max: 180,
+        },
+      ],
     ]
     const builder = new L.U.FormBuilder(this, coordinatesOptions, {
       callback: function () {


### PR DESCRIPTION
Without "step: any", long floats are considered invalid (see the capture)

<img width="393" alt="image" src="https://github.com/umap-project/umap/assets/67073/fa418458-bb84-4c35-840f-94d7253309ab">
