### PR TITLE
Add a popup template to showcase OpenStreetMap data

### DIFF
--- a/umap/static/umap/base.css
+++ b/umap/static/umap/base.css
@@ -584,6 +584,8 @@ i.info {
     text-align: center;
     margin-bottom: 5px;
     display: block;
+    color: black;
+    font-weight: bold;
 }
 .umap-pictogram-choice img {
     vertical-align: middle;

--- a/umap/static/umap/js/umap.browser.js
+++ b/umap/static/umap/js/umap.browser.js
@@ -13,7 +13,7 @@ L.U.Browser = L.Class.extend({
       zoom_to = L.DomUtil.create('i', 'feature-zoom_to', feature_li),
       edit = L.DomUtil.create('i', 'show-on-edit feature-edit', feature_li),
       del = L.DomUtil.create('i', 'show-on-edit feature-delete', feature_li),
-      color = L.DomUtil.create('i', 'feature-color', feature_li),
+      colorBox = L.DomUtil.create('i', 'feature-color', feature_li),
       title = L.DomUtil.create('span', 'feature-title', feature_li),
       symbol = feature._getIconUrl
         ? L.U.Icon.prototype.formatUrl(feature._getIconUrl(), feature)
@@ -22,8 +22,12 @@ L.U.Browser = L.Class.extend({
     edit.title = L._('Edit this feature')
     del.title = L._('Delete this feature')
     title.textContent = feature.getDisplayName() || '—'
-    color.style.backgroundColor = feature.getOption('color')
-    if (symbol) color.style.backgroundImage = `url(${symbol})`
+    const bgcolor = feature.getOption('color')
+    colorBox.style.backgroundColor = bgcolor
+    if (symbol && symbol !== this.map.options.default_iconUrl) {
+      const icon = L.U.Icon.makeIconElement(symbol, colorBox)
+      L.U.Icon.setIconContrast(icon, colorBox, symbol, bgcolor)
+    }
     L.DomEvent.on(
       zoom_to,
       'click',

--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -383,8 +383,8 @@ L.DomUtil.after = (target, el) => {
 }
 
 L.DomUtil.RGBRegex = /rgb *\( *([0-9]{1,3}) *, *([0-9]{1,3}) *, *([0-9]{1,3}) *\)/
-L.DomUtil.TextColorFromBackgroundColor = (el) => {
-  return L.DomUtil.contrastedColor(el) ? '#ffffff' : '#000000'
+L.DomUtil.TextColorFromBackgroundColor = (el, bgcolor) => {
+  return L.DomUtil.contrastedColor(el, bgcolor) ? '#ffffff' : '#000000'
 }
 const _CACHE_CONSTRAST = {}
 L.DomUtil.contrastedColor = (el, bgcolor) => {

--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -260,6 +260,18 @@ L.Util.hasVar = (value) => {
   return typeof value === 'string' && value.indexOf('{') != -1
 }
 
+L.Util.isPath = function (value) {
+  return value && value.length && value.startsWith('/')
+}
+
+L.Util.isRemoteUrl = function (value) {
+  return value && value.length && value.startsWith('http')
+}
+
+L.Util.isDataImage = function (value) {
+  return value && value.length && value.startsWith('data:image')
+}
+
 L.Util.copyToClipboard = function (textToCopy) {
   // https://stackoverflow.com/a/65996386
   // Navigator clipboard api needs a secure context (https)

--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -538,8 +538,8 @@ L.FormBuilder.IconUrl = L.FormBuilder.BlurInput.extend({
     this.footer.innerHTML = ''
     this.buildTabs()
     const value = this.value()
-    if (!value || value.startsWith('/')) this.showSymbolsTab()
-    else if (value.startsWith('http')) this.showURLTab()
+    if (!value || L.Util.isPath(value)) this.showSymbolsTab()
+    else if (L.Util.isRemoteUrl(value) || L.Util.isDataImage(value)) this.showURLTab()
     else this.showCharsTab()
     const closeButton = L.DomUtil.createButton(
       'button action-button',
@@ -596,18 +596,11 @@ L.FormBuilder.IconUrl = L.FormBuilder.BlurInput.extend({
     this.body.innerHTML = ''
   },
 
-  isPath: function () {
-    const value = this.value()
-    return value && value.length && value.startsWith('/')
-  },
-
-  isRemoteUrl: function () {
-    const value = this.value()
-    return value && value.length && value.startsWith('http')
-  },
-
   isImg: function () {
-    return this.isPath() || this.isRemoteUrl()
+    const value = this.value()
+    return (
+      L.Util.isPath(value) || L.Util.isRemoteUrl(value) || L.Util.isDataImage(value)
+    )
   },
 
   updatePreview: function () {
@@ -731,7 +724,10 @@ L.FormBuilder.IconUrl = L.FormBuilder.BlurInput.extend({
 
   showURLTab: function () {
     this.openTab('url')
-    const value = this.isRemoteUrl() ? this.value() : null
+    const value =
+      L.Util.isRemoteUrl(this.value()) || L.Util.isDataImage(this.value())
+        ? this.value()
+        : null
     const input = this.buildInput(this.body, value)
     input.placeholder = L._('Add image URL')
     input.type = 'url'

--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -597,13 +597,6 @@ L.FormBuilder.IconUrl = L.FormBuilder.BlurInput.extend({
     this.body.innerHTML = ''
   },
 
-  isImg: function () {
-    const value = this.value()
-    return (
-      L.Util.isPath(value) || L.Util.isRemoteUrl(value) || L.Util.isDataImage(value)
-    )
-  },
-
   updatePreview: function () {
     this.buttons.innerHTML = ''
     if (this.isDefault()) return
@@ -611,13 +604,7 @@ L.FormBuilder.IconUrl = L.FormBuilder.BlurInput.extend({
       // Do not try to render URL with variables
       const box = L.DomUtil.create('div', 'umap-pictogram-choice', this.buttons)
       L.DomEvent.on(box, 'click', this.onDefine, this)
-      if (this.isImg()) {
-        const img = L.DomUtil.create('img', '', box)
-        img.src = this.value()
-      } else {
-        const el = L.DomUtil.create('span', '', box)
-        el.textContent = this.value()
-      }
+      const icon = L.U.Icon.makeIconElement(this.value(), box)
     }
     this.button = L.DomUtil.createButton(
       'button action-button',
@@ -717,7 +704,7 @@ L.FormBuilder.IconUrl = L.FormBuilder.BlurInput.extend({
 
   showCharsTab: function () {
     this.openTab('chars')
-    const value = !this.isImg() ? this.value() : null
+    const value = !L.U.Icon.isImg(this.value()) ? this.value() : null
     const input = this.buildInput(this.body, value)
     input.placeholder = L._('Type char or paste emoji')
     input.type = 'text'

--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -372,6 +372,7 @@ L.FormBuilder.PopupContent = L.FormBuilder.Select.extend({
     ['Table', L._('Table')],
     ['GeoRSSImage', L._('GeoRSS (title + image)')],
     ['GeoRSSLink', L._('GeoRSS (only link)')],
+    ['OSM', L._('OpenStreetMap')],
   ],
 })
 

--- a/umap/static/umap/js/umap.popup.js
+++ b/umap/static/umap/js/umap.popup.js
@@ -270,24 +270,9 @@ L.U.PopupTemplate.OSM = L.U.PopupTemplate.Default.extend({
     const color = this.feature.getDynamicOption('color')
     title.style.backgroundColor = color
     const iconUrl = this.feature.getDynamicOption('iconUrl')
-    let icon
-    if (
-      L.Util.isPath(iconUrl) ||
-      L.Util.isRemoteUrl(iconUrl) ||
-      L.Util.isDataImage(iconUrl)
-    ) {
-      icon = L.DomUtil.add('img', 'popup-icon', title)
-      icon.src = iconUrl
-    } else {
-      icon = L.DomUtil.add('span', 'popup-icon', title)
-      icon.textContent = iconUrl
-    }
-    if (L.DomUtil.contrastedColor(title, color)) {
-      if (L.Util.isPath(iconUrl) && iconUrl.endsWith('.svg')) {
-        icon.style.filter = 'invert(1)'
-      }
-      title.style.color = 'white'
-    }
+    let icon = L.U.Icon.makeIconElement(iconUrl, title)
+    L.U.Icon.setIconContrast(icon, title, iconUrl, color)
+    if (L.DomUtil.contrastedColor(title, color)) title.style.color = 'white'
     L.DomUtil.add('span', '', title, this.getName())
     const street = props['addr:street']
     if (street) {

--- a/umap/static/umap/js/umap.popup.js
+++ b/umap/static/umap/js/umap.popup.js
@@ -271,6 +271,7 @@ L.U.PopupTemplate.OSM = L.U.PopupTemplate.Default.extend({
     title.style.backgroundColor = color
     const iconUrl = this.feature.getDynamicOption('iconUrl')
     let icon = L.U.Icon.makeIconElement(iconUrl, title)
+    L.DomUtil.addClass(icon, 'icon')
     L.U.Icon.setIconContrast(icon, title, iconUrl, color)
     if (L.DomUtil.contrastedColor(title, color)) title.style.color = 'white'
     L.DomUtil.add('span', '', title, this.getName())

--- a/umap/static/umap/js/umap.popup.js
+++ b/umap/static/umap/js/umap.popup.js
@@ -270,17 +270,17 @@ L.U.PopupTemplate.OSM = L.U.PopupTemplate.Default.extend({
     const color = this.feature.getDynamicOption('color')
     title.style.backgroundColor = color
     const iconUrl = this.feature.getDynamicOption('iconUrl')
-    let img
+    let icon
     if (L.Util.isPath(iconUrl) || L.Util.isRemoteUrl(iconUrl) || L.Util.isDataImage(iconUrl)) {
-      img = L.DomUtil.add('img', 'popup-icon', title)
-      img.src = iconUrl
+      icon = L.DomUtil.add('img', 'popup-icon', title)
+      icon.src = iconUrl
     } else {
-      img = L.DomUtil.add('span', 'popup-icon', title)
-      img.textContent = iconUrl
+      icon = L.DomUtil.add('span', 'popup-icon', title)
+      icon.textContent = iconUrl
     }
     if (L.DomUtil.contrastedColor(title, color)) {
       if (L.Util.isPath(iconUrl) && iconUrl.endsWith('.svg')) {
-        img.style.filter = 'invert(1)'
+        icon.style.filter = 'invert(1)'
       }
       title.style.color = 'white'
     }

--- a/umap/static/umap/js/umap.popup.js
+++ b/umap/static/umap/js/umap.popup.js
@@ -271,7 +271,11 @@ L.U.PopupTemplate.OSM = L.U.PopupTemplate.Default.extend({
     title.style.backgroundColor = color
     const iconUrl = this.feature.getDynamicOption('iconUrl')
     let icon
-    if (L.Util.isPath(iconUrl) || L.Util.isRemoteUrl(iconUrl) || L.Util.isDataImage(iconUrl)) {
+    if (
+      L.Util.isPath(iconUrl) ||
+      L.Util.isRemoteUrl(iconUrl) ||
+      L.Util.isDataImage(iconUrl)
+    ) {
       icon = L.DomUtil.add('img', 'popup-icon', title)
       icon.src = iconUrl
     } else {
@@ -291,29 +295,59 @@ L.U.PopupTemplate.OSM = L.U.PopupTemplate.Default.extend({
       const number = props['addr:housenumber']
       if (number) {
         // Poor way to deal with international forms of writting addresses
-        L.DomUtil.add('span', '', row, `${L._("No.")}: ${number}`)
-        L.DomUtil.add('span', '', row, `${L._("Street")}: ${street}`)
+        L.DomUtil.add('span', '', row, `${L._('No.')}: ${number}`)
+        L.DomUtil.add('span', '', row, `${L._('Street')}: ${street}`)
       } else {
         L.DomUtil.add('span', '', row, street)
       }
     }
     if (props.website) {
-      L.DomUtil.element('a', {href: props.website, textContent: props.website}, container)
+      L.DomUtil.element(
+        'a',
+        { href: props.website, textContent: props.website },
+        container
+      )
     }
     const phone = props.phone || props['contact:phone']
     if (phone) {
-      L.DomUtil.add('div', '', container, L.DomUtil.element('a', {href: `tel:${phone}`, textContent: phone}))
+      L.DomUtil.add(
+        'div',
+        '',
+        container,
+        L.DomUtil.element('a', { href: `tel:${phone}`, textContent: phone })
+      )
     }
     if (props.mobile) {
-      L.DomUtil.add('div', '', container, L.DomUtil.element('a', {href: `tel:${props.mobile}`, textContent: props.mobile}))
+      L.DomUtil.add(
+        'div',
+        '',
+        container,
+        L.DomUtil.element('a', {
+          href: `tel:${props.mobile}`,
+          textContent: props.mobile,
+        })
+      )
     }
     const email = props.email || props['contact:email']
     if (email) {
-      L.DomUtil.add('div', '', container, L.DomUtil.element('a', {href: `mailto:${email}`, textContent: email}))
+      L.DomUtil.add(
+        'div',
+        '',
+        container,
+        L.DomUtil.element('a', { href: `mailto:${email}`, textContent: email })
+      )
     }
     const id = props['@id']
     if (id) {
-      L.DomUtil.add('div', 'osm-link', container, L.DomUtil.element('a', {href: `https://www.openstreetmap.org/${id}`, textContent: L._('See on OpenStreetMap')}))
+      L.DomUtil.add(
+        'div',
+        'osm-link',
+        container,
+        L.DomUtil.element('a', {
+          href: `https://www.openstreetmap.org/${id}`,
+          textContent: L._('See on OpenStreetMap'),
+        })
+      )
     }
     return container
   },

--- a/umap/static/umap/js/umap.popup.js
+++ b/umap/static/umap/js/umap.popup.js
@@ -259,16 +259,62 @@ L.U.PopupTemplate.OSM = L.U.PopupTemplate.Default.extend({
 
   getName: function () {
     const props = this.feature.properties
-    if (L.locale && props[`name:${L.locale}`]) return props[`name:${L.locale}`];
+    if (L.locale && props[`name:${L.locale}`]) return props[`name:${L.locale}`]
     return props.name
   },
 
   renderBody: function () {
     const props = this.feature.properties
-    let kind = props.shop || props.amenity || props.craft
     const container = L.DomUtil.add('div')
-    const kindEl = L.DomUtil.add('h4', '', container, kind)
-    L.DomUtil.add('h3', 'popup-title', container, this.getName())
+    const title = L.DomUtil.add('h3', 'popup-title', container)
+    const color = this.feature.getDynamicOption('color')
+    title.style.backgroundColor = color
+    const iconUrl = this.feature.getDynamicOption('iconUrl')
+    let img
+    if (L.Util.isPath(iconUrl) || L.Util.isRemoteUrl(iconUrl) || L.Util.isDataImage(iconUrl)) {
+      img = L.DomUtil.add('img', 'popup-icon', title)
+      img.src = iconUrl
+    } else {
+      img = L.DomUtil.add('span', 'popup-icon', title)
+      img.textContent = iconUrl
+    }
+    if (L.DomUtil.contrastedColor(title, color)) {
+      if (L.Util.isPath(iconUrl) && iconUrl.endsWith('.svg')) {
+        img.style.filter = 'invert(1)'
+      }
+      title.style.color = 'white'
+    }
+    L.DomUtil.add('span', '', title, this.getName())
+    const street = props['addr:street']
+    if (street) {
+      const row = L.DomUtil.add('address', 'address', container)
+      const number = props['addr:housenumber']
+      if (number) {
+        // Poor way to deal with international forms of writting addresses
+        L.DomUtil.add('span', '', row, `${L._("No.")}: ${number}`)
+        L.DomUtil.add('span', '', row, `${L._("Street")}: ${street}`)
+      } else {
+        L.DomUtil.add('span', '', row, street)
+      }
+    }
+    if (props.website) {
+      L.DomUtil.element('a', {href: props.website, textContent: props.website}, container)
+    }
+    const phone = props.phone || props['contact:phone']
+    if (phone) {
+      L.DomUtil.add('div', '', container, L.DomUtil.element('a', {href: `tel:${phone}`, textContent: phone}))
+    }
+    if (props.mobile) {
+      L.DomUtil.add('div', '', container, L.DomUtil.element('a', {href: `tel:${props.mobile}`, textContent: props.mobile}))
+    }
+    const email = props.email || props['contact:email']
+    if (email) {
+      L.DomUtil.add('div', '', container, L.DomUtil.element('a', {href: `mailto:${email}`, textContent: email}))
+    }
+    const id = props['@id']
+    if (id) {
+      L.DomUtil.add('div', 'osm-link', container, L.DomUtil.element('a', {href: `https://www.openstreetmap.org/${id}`, textContent: L._('See on OpenStreetMap')}))
+    }
     return container
   },
 })

--- a/umap/static/umap/js/umap.popup.js
+++ b/umap/static/umap/js/umap.popup.js
@@ -251,3 +251,24 @@ L.U.PopupTemplate.GeoRSSLink = L.U.PopupTemplate.Default.extend({
     return a
   },
 })
+
+L.U.PopupTemplate.OSM = L.U.PopupTemplate.Default.extend({
+  options: {
+    className: 'umap-openstreetmap',
+  },
+
+  getName: function () {
+    const props = this.feature.properties
+    if (L.locale && props[`name:${L.locale}`]) return props[`name:${L.locale}`];
+    return props.name
+  },
+
+  renderBody: function () {
+    const props = this.feature.properties
+    let kind = props.shop || props.amenity || props.craft
+    const container = L.DomUtil.add('div')
+    const kindEl = L.DomUtil.add('h4', '', container, kind)
+    L.DomUtil.add('h3', 'popup-title', container, this.getName())
+    return container
+  },
+})

--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -1010,29 +1010,36 @@ a.add-datalayer:hover,
     background-color: #f8f8f3;
 }
 .umap-browse-features .feature-color {
-    box-shadow: 0 0 4px 0 black inset;
-    background-size: 70% 70%;
-    border: 4px solid #f8f8f3;
+    box-shadow: 0 0 2px 0 black inset;
     cursor: inherit;
     -moz-box-sizing:border-box;
     -webkit-box-sizing:border-box;
     box-sizing: border-box;
-    background-position: center;
+    background: none;
     display: inline-block;
     padding: 0;
     width: 24px;
+    text-align: center;
+    margin-left: 5px;
+}
+.umap-browse-features .feature-color img {
+    width: 24px;
+}
+.umap-browse-features .feature-color span {
+    font-style: normal;
+    font-weight: bold;
 }
 .umap-browse-features .polygon .feature-color,
 .umap-browse-features .polyline .feature-color {
-    box-shadow: 0 0 4px 0 black inset;
+    box-shadow: 0 0 2px 0 black inset;
     background-image: url('./img/24.svg');
     background-size: 500%;
 }
 .umap-browse-features .polyline .feature-color {
-    background-position: -48px -16px;
+    background-position: -72px -23px;
 }
 .umap-browse-features .polygon .feature-color {
-    background-position: -32px -16px;
+    background-position: -48px -25px;
 }
 .show-on-edit {
     display: none!important;
@@ -1379,7 +1386,6 @@ span.popup-icon {
 .umap-div-icon .icon_container span,
 .umap-drop-icon .icon_container span {
     vertical-align: middle;
-    color: white;
     font-weight: bold;
 }
 .umap-circle-icon {

--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -1266,6 +1266,31 @@ a.add-datalayer:hover,
 .umap-popup a:hover {
     text-decoration: underline;
 }
+.popup-title {
+    display: flex;
+    align-items: center;
+}
+.popup-title img {
+    margin: 0 5px;
+}
+a[href^='mailto']::before {
+  content: '🖃 ';
+}
+a[href^='tel']::before {
+  content: '🕿 ';
+}
+address span {
+    padding-right: 5px;
+}
+.osm-link {
+    margin-top: 10px;
+    text-align: right;
+    font-style: italic;
+}
+span.popup-icon {
+    padding: 5px;
+}
+
 
 /* ************* */
 /* Marker's Icon */

--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -1277,8 +1277,8 @@ a.add-datalayer:hover,
     display: flex;
     align-items: center;
 }
-.popup-title img {
-    margin: 0 5px;
+.popup-title .icon {
+    margin: 5px;
 }
 a[href^='mailto']::before {
   content: '🖃 ';


### PR DESCRIPTION
![image](https://github.com/umap-project/umap/assets/146023/d2b99631-6f49-4e0e-ab5c-3194374649f5)

It's a popup template that know how to display data coming from OpenStreetMap. At this stage, it's very basic and only display contact informations, but I'd like to push such a minimalist version and see how users use it before putting more energy on it.

What's not done and may be in further steps:
- display a i18n label (bakery, swimming pool)
- automatically display an icon if none is set on the layer
- show opening hours, or at least show if the shop/amenity is open
- show more specific tags like the cuisine for a restaurant, the organic tag, etc.
- connect to panoramax/mapilary to have a picture…

There is no intention to cover all and every possible case, but only to focus on the main tags (shop/amenity…).