### PR TITLE
Allow to type a latlng in the search box

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "leaflet.locatecontrol": "^0.79.0",
         "leaflet.markercluster": "^1.5.3",
         "leaflet.path.drag": "0.0.6",
-        "leaflet.photon": "0.8.0",
+        "leaflet.photon": "0.9.0",
         "osmtogeojson": "^3.0.0-beta.3",
         "simple-statistics": "^7.8.3",
         "togpx": "^0.5.4",
@@ -1465,9 +1465,9 @@
       "integrity": "sha1-bZw68LnXsDJUSuFr/eaI8BYFFKA="
     },
     "node_modules/leaflet.photon": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/leaflet.photon/-/leaflet.photon-0.8.0.tgz",
-      "integrity": "sha512-uvCPocNvRJaArW8yPm6K4bkgvoMCbCOA9tgFlQfOVw+mRmN4jbkuEFoSP0nJhj8UKIOWsRtGfOjxtzaJyZuciw=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/leaflet.photon/-/leaflet.photon-0.9.0.tgz",
+      "integrity": "sha512-qLZzYqBAHvOGgf/ymj3zdknlR1zfVZTPSF02wfES3tWR0iZA48HaxpFTZ0ZLflHxsDuQf6Hl+03xwBAHHQTslA=="
     },
     "node_modules/lebab": {
       "version": "3.2.1",
@@ -3674,9 +3674,9 @@
       "integrity": "sha1-bZw68LnXsDJUSuFr/eaI8BYFFKA="
     },
     "leaflet.photon": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/leaflet.photon/-/leaflet.photon-0.8.0.tgz",
-      "integrity": "sha512-uvCPocNvRJaArW8yPm6K4bkgvoMCbCOA9tgFlQfOVw+mRmN4jbkuEFoSP0nJhj8UKIOWsRtGfOjxtzaJyZuciw=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/leaflet.photon/-/leaflet.photon-0.9.0.tgz",
+      "integrity": "sha512-qLZzYqBAHvOGgf/ymj3zdknlR1zfVZTPSF02wfES3tWR0iZA48HaxpFTZ0ZLflHxsDuQf6Hl+03xwBAHHQTslA=="
     },
     "lebab": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "leaflet.locatecontrol": "^0.79.0",
     "leaflet.markercluster": "^1.5.3",
     "leaflet.path.drag": "0.0.6",
-    "leaflet.photon": "0.8.0",
+    "leaflet.photon": "0.9.0",
     "osmtogeojson": "^3.0.0-beta.3",
     "simple-statistics": "^7.8.3",
     "togpx": "^0.5.4",

--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -1353,6 +1353,7 @@ L.U.StarControl = L.Control.extend({
 
 L.U.Search = L.PhotonSearch.extend({
   initialize: function (map, input, options) {
+    this.options.placeholder = L._('Type a place name or coordinates')
     L.PhotonSearch.prototype.initialize.call(this, map, input, options)
     this.options.url = map.options.urls.search
     if (map.options.maxBounds) this.options.bbox = map.options.maxBounds.toBBoxString()


### PR DESCRIPTION
When entering a string in a form of a latlng, we'll do two things:
- add a result that allow to center the map on this latlng (and to create a new point if edit mode is enabled)
- do a reverse search and display it result if any

![image](https://github.com/umap-project/umap/assets/146023/82b8997f-df1e-45d6-8081-c77a11c41824)

![image](https://github.com/umap-project/umap/assets/146023/2a69db73-9599-4f86-bcb7-c3ac010af2ac)

fix #1000
cf #1001