### PR TITLE
Do not fail on greedyTemplate when description is an object

### DIFF
--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -176,6 +176,8 @@ L.Util.greedyTemplate = (str, data, ignore) => {
     return value
   }
 
+  if (typeof str !== 'string') return ''
+
   return str.replace(
     /\{ *([^\{\}/\-]+)(?:\|("[^"]*"))? *\}/g,
     (str, key, staticFallback) => {


### PR DESCRIPTION
Quick fix for not failing with an error in case of #1481