### PR TITLE
Be more explicit on changed fields when updating choropleth form

### DIFF
--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -9,7 +9,7 @@ L.U.Layer = {
     return []
   },
 
-  postUpdate: function () {},
+  onEdit: function () {},
 
   hasDataVisible: function () {
     return !!Object.keys(this._layers).length
@@ -104,13 +104,13 @@ L.U.Layer.Cluster = L.MarkerClusterGroup.extend({
     ]
   },
 
-  postUpdate: function (e) {
-    if (e.helper.field === 'options.cluster.radius') {
+  onEdit: function (field, builder) {
+    if (field === 'options.cluster.radius') {
       // No way to reset radius of an already instanciated MarkerClusterGroup...
       this.datalayer.resetLayer(true)
       return
     }
-    if (e.helper.field === 'options.color') {
+    if (field === 'options.color') {
       this.options.polygonOptions.color = this.datalayer.getColor()
     }
   },
@@ -234,9 +234,7 @@ L.U.Layer.Choropleth = L.FeatureGroup.extend({
     L.FeatureGroup.prototype.onAdd.call(this, map)
   },
 
-  postUpdate: function (e) {
-    const field = e.helper.field,
-      builder = e.helper.builder
+  onEdit: function (field, builder) {
     // If user touches the breaks, then force manual mode
     if (field === 'options.choropleth.breaks') {
       this.datalayer.options.choropleth.mode = 'manual'
@@ -387,12 +385,12 @@ L.U.Layer.Heat = L.HeatLayer.extend({
     ]
   },
 
-  postUpdate: function (e) {
-    if (e.helper.field === 'options.heat.intensityProperty') {
+  onEdit: function (field, builder) {
+    if (field === 'options.heat.intensityProperty') {
       this.datalayer.resetLayer(true) // We need to repopulate the latlngs
       return
     }
-    if (e.helper.field === 'options.heat.radius') {
+    if (field === 'options.heat.radius') {
       this.options.radius = this.datalayer.options.heat.radius
     }
     this._updateOptions()
@@ -1204,11 +1202,12 @@ L.U.DataLayer = L.Evented.extend({
     ]
 
     const redrawCallback = function (e) {
+      const field = e.helper.field,
+        builder = e.helper.builder
       this.hide()
-      this.layer.postUpdate(e)
+      this.layer.onEdit(field, builder)
       this.show()
     }
-
     builder = new L.U.FormBuilder(this, shapeOptions, {
       id: 'datalayer-advanced-properties',
       callback: redrawCallback,

--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -235,13 +235,18 @@ L.U.Layer.Choropleth = L.FeatureGroup.extend({
   },
 
   postUpdate: function (e) {
-    if (e.helper.field === 'options.choropleth.breaks') {
+    const field = e.helper.field,
+      builder = e.helper.builder
+    // If user touches the breaks, then force manual mode
+    if (field === 'options.choropleth.breaks') {
       this.datalayer.options.choropleth.mode = 'manual'
-      e.helper.builder.helpers['options.choropleth.mode'].fetch()
+      builder.helpers['options.choropleth.mode'].fetch()
     }
     this.computeBreaks()
-    if (e.helper.field !== 'options.choropleth.breaks') {
-      e.helper.builder.helpers['options.choropleth.breaks'].fetch()
+    // If user changes the mode or the number of classes,
+    // then update the breaks input value
+    if (field === 'options.choropleth.mode' || field === 'options.choropleth.classes') {
+      builder.helpers['options.choropleth.breaks'].fetch()
     }
   },
 


### PR DESCRIPTION
The `postUpdate` method of the Choropleth layer is called after any form field change, even if this field is not in the dedicated choropleth helper. So the previous check was too broad, and it would try to fetch the breaks input value on any form helper, which would fail if someone change any "non choropleth" property (like the colour)