### PR TITLE
Fix preview of TMS TileLayer preview

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -1199,11 +1199,21 @@ L.U.TileLayerControl = L.Control.IconLayers.extend({
     if (!layers) {
       layers = []
       this.map.eachTileLayer((layer) => {
-        layers.push({
-          title: layer.options.name,
-          layer: layer,
-          icon: L.Util.template(layer.options.url_template, this.map.demoTileInfos),
-        })
+        try {
+          // We'd like to use layer.getTileUrl, but this method will only work
+          // when the tilelayer is actually added to the map (needs this._tileZoom
+          // to be defined)
+          // Fixme when https://github.com/Leaflet/Leaflet/pull/9201 is released
+          const icon = L.Util.template(layer.options.url_template, this.map.demoTileInfos)
+          layers.push({
+            title: layer.options.name,
+            layer: layer,
+            icon: icon,
+          })
+        } catch (e) {
+          // Skip this tilelayer
+          console.error(e)
+        }
       })
     }
     const maxShown = 10

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -29,7 +29,12 @@ L.Map.mergeOptions({
   name: '',
   description: '',
   displayPopupFooter: false,
-  demoTileInfos: { s: 'a', z: 9, x: 265, y: 181, r: '' },
+  // When a TileLayer is in TMS mode, it needs -y instead of y.
+  // This is usually handled by the TileLayer instance itself, but
+  // we cannot rely on this because of the y is overriden by Leaflet
+  // See https://github.com/Leaflet/Leaflet/pull/9201
+  // And let's remove this -y when this PR is merged and released.
+  demoTileInfos: { s: 'a', z: 9, x: 265, y: 181, '-y': 181, r: '' },
   licences: [],
   licence: '',
   enableMarkerDraw: true,


### PR DESCRIPTION
This is not the ideal fix, instead we'd prefer to use `TileLayer.getTileUrl`, but this is not possible yet.

cf https://github.com/Leaflet/Leaflet/pull/9201

cf https://lists.openstreetmap.org/pipermail/umap/2023-December/000557.html