### PR TITLE
Add a small box-shadow to tilelayer preview

### DIFF
--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -164,7 +164,7 @@
 .leaflet-iconLayers-layer {
     width: 38px;
     height: 38px;
-    box-shadow: none;
+    box-shadow: 0px 0px 2px #444;
     border: 1px solid #bbb;
     border-radius: 4px;
 }


### PR DESCRIPTION
In some situation, the preview is very similar to the background, so it's not visible enough.

fix #1485

![image](https://github.com/umap-project/umap/assets/146023/4b670c4c-834e-4da6-a71b-25b93fd13b67)

![image](https://github.com/umap-project/umap/assets/146023/b3912fe0-a736-4898-88b5-5ec1d90c40e9)
