### PR TITLE
fix dirty flags when re-ordering layers

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -632,12 +632,14 @@ L.U.DataLayersControl = L.Control.extend({
       function (e) {
         const layer = this.map.datalayers[e.src.dataset.id],
           other = this.map.datalayers[e.dst.dataset.id],
-          minIndex = Math.min(e.initialIndex, e.finalIndex)
+          minIndex = Math.min(layer.getRank(), other.getRank()),
+          maxIndex = Math.max(layer.getRank(), other.getRank())
         if (e.finalIndex === 0) layer.bringToTop()
         else if (e.finalIndex > e.initialIndex) layer.insertBefore(other)
         else layer.insertAfter(other)
         this.map.eachDataLayerReverse((datalayer) => {
-          if (datalayer.getRank() >= minIndex) datalayer.isDirty = true
+          if (datalayer.getRank() >= minIndex && datalayer.getRank() <= maxIndex)
+            datalayer.isDirty = true
         })
         this.map.indexDatalayers()
       },


### PR DESCRIPTION
The index of the top layer in the view starts with zero, while the rank of the layers count backwards. Thus moving the second-last to the last position should set the dirty flag of rank 0 and 1. Instead the former implementation set the dirty flag for layers >= 5, when moving "Red" to the bottom in [the test map](https://umap.openstreetmap.fr/fr/map/test-ordering_994821) - resulting in the wrong layers saved.

Fixes #375