### PR TITLE
Move layer specific settings to a dedicated fieldset

### DIFF
--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -376,12 +376,15 @@ L.FormBuilder.PopupContent = L.FormBuilder.Select.extend({
 })
 
 L.FormBuilder.LayerTypeChooser = L.FormBuilder.Select.extend({
-  selectOptions: [
-    ['Default', L._('Default')],
-    ['Cluster', L._('Clustered')],
-    ['Heat', L._('Heatmap')],
-    ['Choropleth', L._('Choropleth')],
-  ],
+  getOptions: function () {
+    const layer_classes = [
+      L.U.Layer.Default,
+      L.U.Layer.Cluster,
+      L.U.Layer.Heat,
+      L.U.Layer.Choropleth,
+    ]
+    return layer_classes.map((class_) => [class_.TYPE, class_.NAME])
+  },
 })
 
 L.FormBuilder.SlideshowDelay = L.FormBuilder.IntSelect.extend({

--- a/umap/tests/integration/test_edit_datalayer.py
+++ b/umap/tests/integration/test_edit_datalayer.py
@@ -1,0 +1,45 @@
+from playwright.sync_api import expect
+
+
+def test_should_have_fieldset_for_layer_type_properties(page, live_server, tilelayer):
+    page.goto(f"{live_server.url}/en/map/new/")
+
+    # Open DataLayers list
+    button = page.get_by_title("Manage Layers")
+    expect(button).to_be_visible()
+    button.click()
+
+    edit = page.locator("#umap-ui-container").get_by_title("Edit", exact=True)
+    expect(edit).to_be_visible()
+    edit.click()
+
+    select = page.locator("#umap-ui-container .umap-field-type select")
+    expect(select).to_be_visible()
+
+    choropleth_header = page.get_by_text("Choropleth: settings")
+    heat_header = page.get_by_text("Heatmap: settings")
+    cluster_header = page.get_by_text("Clustered: settings")
+    expect(choropleth_header).to_be_hidden()
+    expect(heat_header).to_be_hidden()
+    expect(cluster_header).to_be_hidden()
+
+    # Switching to Choropleth should add a dedicated fieldset
+    select.select_option("Choropleth")
+    expect(choropleth_header).to_be_visible()
+    expect(heat_header).to_be_hidden()
+    expect(cluster_header).to_be_hidden()
+
+    select.select_option("Heat")
+    expect(heat_header).to_be_visible()
+    expect(choropleth_header).to_be_hidden()
+    expect(cluster_header).to_be_hidden()
+
+    select.select_option("Cluster")
+    expect(cluster_header).to_be_visible()
+    expect(choropleth_header).to_be_hidden()
+    expect(heat_header).to_be_hidden()
+
+    select.select_option("Default")
+    expect(choropleth_header).to_be_hidden()
+    expect(heat_header).to_be_hidden()
+    expect(cluster_header).to_be_hidden()


### PR DESCRIPTION
Instead of having them at the end of "Advanced properties", there is now a dedicated box:

![image](https://github.com/umap-project/umap/assets/146023/8c2a46aa-f881-44a8-8d64-73bb983c5317)

cf #1490