### PR TITLE
Introduce UMAP_HOME_FEED to control which maps are shown on the home page

### DIFF
--- a/docs/config/settings.md
+++ b/docs/config/settings.md
@@ -218,6 +218,13 @@ ready for production use (no backup, etc.)
 
 Link to show on the header under the "Feedback and help" label.
 
+#### UMAP_HOME_FEED
+
+Which feed to display on the home page. Three valid values:
+- `"latest"`, which shows the latest maps (default)
+- `"highlighted"`, which shows the maps that have been starred by a staff member
+- `None`, which does not show any map on the home page
+
 #### UMAP_MAPS_PER_PAGE
 
 How many maps to show in maps list, like search or home page.

--- a/umap/settings/base.py
+++ b/umap/settings/base.py
@@ -249,6 +249,7 @@ DATABASES = {"default": env.db(default="postgis://localhost:5432/umap")}
 UMAP_DEFAULT_SHARE_STATUS = None
 UMAP_DEFAULT_EDIT_STATUS = None
 UMAP_DEFAULT_FEATURES_HAVE_OWNERS = False
+UMAP_HOME_FEED = "latest"
 
 UMAP_READONLY = env("UMAP_READONLY", default=False)
 UMAP_GZIP = True

--- a/umap/templates/umap/home.html
+++ b/umap/templates/umap/home.html
@@ -10,7 +10,9 @@
     </div>
   {% endif %}
   <div class="wrapper">
-    <h2 class="section">{% blocktrans %}Get inspired, browse maps{% endblocktrans %}</h2>
-    <div class="map_list row">{% include "umap/map_list.html" %}</div>
+    {% if maps %}
+      <h2 class="section">{% blocktrans %}Get inspired, browse maps{% endblocktrans %}</h2>
+      <div class="map_list row">{% include "umap/map_list.html" %}</div>
+    {% endif %}
   </div>
 {% endblock maincontent %}

--- a/umap/views.py
+++ b/umap/views.py
@@ -119,13 +119,26 @@ class PublicMapsMixin(object):
         maps = qs.order_by("-modified_at")
         return maps
 
+    def get_highlighted_maps(self):
+        staff = User.objects.filter(is_staff=True)
+        stars = Star.objects.filter(by__in=staff).values("map")
+        qs = Map.public.filter(pk__in=stars)
+        maps = qs.order_by("-modified_at")
+        return maps
+
 
 class Home(PaginatorMixin, TemplateView, PublicMapsMixin):
     template_name = "umap/home.html"
     list_template_name = "umap/map_list.html"
 
     def get_context_data(self, **kwargs):
-        maps = self.get_public_maps()
+        if settings.UMAP_HOME_FEED is None:
+            maps = []
+        elif settings.UMAP_HOME_FEED == "highlighted":
+            maps = self.get_highlighted_maps()
+        else:
+            maps = self.get_public_maps()
+        maps = self.paginate(maps, settings.UMAP_MAPS_PER_PAGE)
 
         demo_map = None
         if hasattr(settings, "UMAP_DEMO_PK"):
@@ -140,8 +153,6 @@ class Home(PaginatorMixin, TemplateView, PublicMapsMixin):
                 showcase_map = Map.public.get(pk=settings.UMAP_SHOWCASE_PK)
             except Map.DoesNotExist:
                 pass
-
-        maps = self.paginate(maps, settings.UMAP_MAPS_PER_PAGE)
 
         return {
             "maps": maps,


### PR DESCRIPTION
For now we have only three modes:
- latest, which is the default and shows the last updated maps
- highlighted, which shows only the map that have been starred by a least one staff member
- None, which does not show any map