### PR TITLE
fix: honour datalayersControl=expanded in querystring

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -122,6 +122,11 @@ L.U.Map.include({
         `${this.HIDDABLE_CONTROLS[i]}Control`
       )
     }
+    // Specific case for datalayersControl
+    // which accept "expanded" value, on top of true/false/null
+    if (L.Util.queryString('datalayersControl') === 'expanded') {
+      L.Util.setFromQueryString(this.options, 'datalayersControl')
+    }
     this.datalayersOnLoad = L.Util.queryString('datalayers')
     this.options.onLoadPanel = L.Util.queryString(
       'onLoadPanel',

--- a/umap/tests/integration/test_querystring.py
+++ b/umap/tests/integration/test_querystring.py
@@ -1,0 +1,39 @@
+import pytest
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.django_db
+
+
+def test_scale_control(map, live_server, datalayer, page):
+    control = page.locator(".leaflet-control-scale")
+    page.goto(f"{live_server.url}{map.get_absolute_url()}")
+    expect(control).to_be_visible()
+    page.goto(f"{live_server.url}{map.get_absolute_url()}?scaleControl=false")
+    expect(control).to_be_hidden()
+
+
+def test_datalayers_control(map, live_server, datalayer, page):
+    control = page.locator(".umap-browse-toggle")
+    box = page.locator(".umap-browse-datalayers")
+    more = page.get_by_title("More controls")
+    page.goto(f"{live_server.url}{map.get_absolute_url()}")
+    expect(control).to_be_visible()
+    expect(box).to_be_hidden()
+    page.goto(f"{live_server.url}{map.get_absolute_url()}?datalayersControl=true")
+    expect(control).to_be_visible()
+    expect(box).to_be_hidden()
+    page.goto(f"{live_server.url}{map.get_absolute_url()}?datalayersControl=null")
+    expect(control).to_be_hidden()
+    expect(more).to_be_visible()
+    more.click()
+    expect(control).to_be_visible()
+    expect(box).to_be_hidden()
+    page.goto(f"{live_server.url}{map.get_absolute_url()}?datalayersControl=false")
+    expect(control).to_be_hidden()
+    expect(more).to_be_visible()
+    more.click()
+    expect(control).to_be_hidden()
+    expect(box).to_be_hidden()
+    page.goto(f"{live_server.url}{map.get_absolute_url()}?datalayersControl=expanded")
+    expect(control).to_be_hidden()
+    expect(box).to_be_visible()


### PR DESCRIPTION
`datalayersControl` is an exception among the HIDDABLE_CONTROLS: while all other controls have a ternary value true/false/null, it also accepts `expanded`.

I've found cleaner to add an exception in the code instead of trying to factorise the utils for this exception, but this may be discussed. :)

fix #1525