### PR TITLE
Use custom storage instead of django-compressor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ site/*
 node_modules
 umap.conf
 data
+static
 
 ### Python ###
 # Byte-compiled / optimized / DLL files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
 dependencies = [
   "Django==4.2",
   "django-agnocomplete==2.2.0",
-  "django-compressor==4.3.1",
   "django-environ==0.10.0",
   "django-probes==1.7.0",
   "Pillow==10.0.1",

--- a/umap/settings/base.py
+++ b/umap/settings/base.py
@@ -119,7 +119,6 @@ INSTALLED_APPS = (
     "django.contrib.gis",
     "django_probes",
     "umap",
-    "compressor",
     "social_django",
     # See https://github.com/peopledoc/django-agnocomplete/commit/26eda2dfa4a2f8a805ca2ea19a0c504b9d773a1c
     # Django does not find the app config in the default place, so the app is not loaded
@@ -163,9 +162,16 @@ MEDIA_ROOT = os.path.join("uploads")
 STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.FileSystemFinder",
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
-    "compressor.finders.CompressorFinder",
 ]
 STATICFILES_DIRS = []  # May be extended when using UMAP_CUSTOM_STATICS
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "umap.utils.UmapManifestStaticFilesStorage",
+    },
+}
 
 # =============================================================================
 # Templates
@@ -262,9 +268,6 @@ LEAFLET_ZOOM = env.int("LEAFLET_ZOOM", default=6)
 # =============================================================================
 # Third party app settings
 # =============================================================================
-COMPRESS_ENABLED = True
-COMPRESS_OFFLINE = True
-
 LOGIN_URL = "login"
 SOCIAL_AUTH_LOGIN_REDIRECT_URL = "/login/popup/end/"
 

--- a/umap/settings/local.py.sample
+++ b/umap/settings/local.py.sample
@@ -29,9 +29,6 @@ DATABASES = {
     }
 }
 
-COMPRESS_ENABLED = False
-COMPRESS_OFFLINE = True
-
 LANGUAGE_CODE = "en"
 
 # Set to False if login into django account should not be possible. You can

--- a/umap/templates/base.html
+++ b/umap/templates/base.html
@@ -1,4 +1,4 @@
-{% load compress umap_tags i18n %}
+{% load umap_tags i18n static %}
 <!DOCTYPE html>
 <html {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
   <head>
@@ -17,13 +17,13 @@
           content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     {# See https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs #}
     <link rel="icon"
-          href="{{ STATIC_URL }}umap/favicons/favicon.ico"
+          href="{% static 'umap/favicons/favicon.ico' %}"
           sizes="32x32">
     <link rel="icon"
-          href="{{ STATIC_URL }}umap/favicons/icon.svg"
+          href="{% static 'umap/favicons/icon.svg' %}"
           type="image/svg+xml">
     <link rel="apple-touch-icon"
-          href="{{ STATIC_URL }}umap/favicons/apple-touch-icon.png">
+          href="{% static 'umap/favicons/apple-touch-icon.png' %}">
     <!-- 180×180 -->
     <link rel="manifest" href="/manifest.webmanifest">
   </head>

--- a/umap/templates/umap/about_summary.html
+++ b/umap/templates/umap/about_summary.html
@@ -1,9 +1,9 @@
-{% load i18n %}
+{% load i18n static %}
 <div class="wrapper about_summary  highlights">
   <div class="row">
     <div class="col quarter mwide">
       <img class="colophon"
-           src="{{ STATIC_URL }}umap/img/osm.svg"
+           src="{% static 'umap/img/osm.svg' %}"
            alt=""
            width="128px"
            height="128px" />
@@ -13,7 +13,7 @@
     </div>
     <div class="col umap-features-list half mwide">
       <img class="colophon"
-           src="{{ STATIC_URL }}umap/img/edit.svg"
+           src="{% static 'umap/img/edit.svg' %}"
            alt=""
            width="128px"
            height="128px" />
@@ -29,7 +29,7 @@
     </div>
     <div class="col quarter mwide">
       <img class="colophon"
-           src="{{ STATIC_URL }}umap/img/opensource.svg"
+           src="{% static 'umap/img/opensource.svg' %}"
            alt=""
            width="128px"
            height="128px" />

--- a/umap/templates/umap/content.html
+++ b/umap/templates/umap/content.html
@@ -1,12 +1,10 @@
 {% extends "base.html" %}
-{% load umap_tags compress i18n %}
+{% load umap_tags i18n %}
 {% block body_class %}
   content
 {% endblock body_class %}
 {% block extra_head %}
-  {% compress css %}
-    {% umap_css %}
-  {% endcompress css %}
+  {% umap_css %}
   {% umap_js %}
 {% endblock extra_head %}
 {% block header %}

--- a/umap/templates/umap/css.html
+++ b/umap/templates/umap/css.html
@@ -1,28 +1,30 @@
+{% load static %}
+
 <link rel="stylesheet"
-      href="{{ STATIC_URL }}umap/vendors/leaflet/leaflet.css" />
+      href="{% static 'umap/vendors/leaflet/leaflet.css' %}" />
 <link rel="stylesheet"
-      href="{{ STATIC_URL }}umap/vendors/markercluster/MarkerCluster.css" />
+      href="{% static 'umap/vendors/markercluster/MarkerCluster.css' %}" />
 <link rel="stylesheet"
-      href="{{ STATIC_URL }}umap/vendors/markercluster/MarkerCluster.Default.css" />
+      href="{% static 'umap/vendors/markercluster/MarkerCluster.Default.css' %}" />
 <link rel="stylesheet"
-      href="{{ STATIC_URL }}umap/vendors/editinosm/Leaflet.EditInOSM.css" />
+      href="{% static 'umap/vendors/editinosm/Leaflet.EditInOSM.css' %}" />
 <link rel="stylesheet"
-      href="{{ STATIC_URL }}umap/vendors/minimap/Control.MiniMap.css" />
+      href="{% static 'umap/vendors/minimap/Control.MiniMap.css' %}" />
 <link rel="stylesheet"
-      href="{{ STATIC_URL }}umap/vendors/contextmenu/leaflet.contextmenu.css" />
+      href="{% static 'umap/vendors/contextmenu/leaflet.contextmenu.css' %}" />
 <link rel="stylesheet"
-      href="{{ STATIC_URL }}umap/vendors/toolbar/leaflet.toolbar.css" />
+      href="{% static 'umap/vendors/toolbar/leaflet.toolbar.css' %}" />
 <link rel="stylesheet"
-      href="{{ STATIC_URL }}umap/vendors/measurable/Leaflet.Measurable.css" />
+      href="{% static 'umap/vendors/measurable/Leaflet.Measurable.css' %}" />
 <link rel="stylesheet"
-      href="{{ STATIC_URL }}umap/vendors/fullscreen/leaflet.fullscreen.css" />
+      href="{% static 'umap/vendors/fullscreen/leaflet.fullscreen.css' %}" />
 <link rel="stylesheet"
-      href="{{ STATIC_URL }}umap/vendors/locatecontrol/L.Control.Locate.css" />
+      href="{% static 'umap/vendors/locatecontrol/L.Control.Locate.css' %}" />
 <link rel="stylesheet"
-      href="{{ STATIC_URL }}umap/vendors/iconlayers/iconLayers.css" />
-<link rel="stylesheet" href="{{ STATIC_URL }}umap/font.css">
-<link rel="stylesheet" href="{{ STATIC_URL }}umap/base.css">
-<link rel="stylesheet" href="{{ STATIC_URL }}umap/content.css">
-<link rel="stylesheet" href="{{ STATIC_URL }}umap/nav.css">
-<link rel="stylesheet" href="{{ STATIC_URL }}umap/map.css" />
-<link rel="stylesheet" href="{{ STATIC_URL }}umap/theme.css">
+      href="{% static 'umap/vendors/iconlayers/iconLayers.css' %}" />
+<link rel="stylesheet" href="{% static 'umap/font.css' %}">
+<link rel="stylesheet" href="{% static 'umap/base.css' %}">
+<link rel="stylesheet" href="{% static 'umap/content.css' %}">
+<link rel="stylesheet" href="{% static 'umap/nav.css' %}">
+<link rel="stylesheet" href="{% static 'umap/map.css' %}" />
+<link rel="stylesheet" href="{% static 'umap/theme.css' %}">

--- a/umap/templates/umap/js.html
+++ b/umap/templates/umap/js.html
@@ -28,7 +28,7 @@
 <script src="{% static 'umap/vendors/colorbrewer/colorbrewer.js' %}" defer></script>
 <script src="{% static 'umap/vendors/simple-statistics/simple-statistics.min.js' %}" defer></script>
 {% if locale %}
-    {% with 'umap/locale/'|add:locale|add:'.js' as path %}
+    {% with "umap/locale/"|add:locale|add:".js" as path %}
         <script src="{% static path %}" defer></script>
     {% endwith %}
 {% endif %}

--- a/umap/templates/umap/js.html
+++ b/umap/templates/umap/js.html
@@ -27,7 +27,11 @@
 <script src="{% static 'umap/vendors/dompurify/purify.js' %}" defer></script>
 <script src="{% static 'umap/vendors/colorbrewer/colorbrewer.js' %}" defer></script>
 <script src="{% static 'umap/vendors/simple-statistics/simple-statistics.min.js' %}" defer></script>
-{% if locale %}<script src="{% static 'umap/locale/fr.js' %}" defer></script>{% endif %}{# TODO: handle dynamic locale! #}
+{% if locale %}
+    {% with 'umap/locale/'|add:locale|add:'.js' as path %}
+        <script src="{% static path %}" defer></script>
+    {% endwith %}
+{% endif %}
 <script src="{% static 'umap/js/umap.core.js' %}" defer></script>
 <script src="{% static 'umap/js/umap.autocomplete.js' %}" defer></script>
 <script src="{% static 'umap/js/umap.popup.js' %}" defer></script>

--- a/umap/templates/umap/js.html
+++ b/umap/templates/umap/js.html
@@ -1,62 +1,49 @@
-{% load compress %}
-{% compress js %}
-        <script type="module" src="{{ STATIC_URL }}umap/js/modules/global.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/editable/Path.Drag.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/editable/Leaflet.Editable.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/hash/leaflet-hash.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/i18n/Leaflet.i18n.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/editinosm/Leaflet.EditInOSM.js"
-                defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/minimap/Control.MiniMap.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/csv2geojson/csv2geojson.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/togeojson/togeojson.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/osmtogeojson/osmtogeojson.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/loading/Control.Loading.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/markercluster/leaflet.markercluster-src.js"
-                defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/contextmenu/leaflet.contextmenu.js"
-                defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/photon/leaflet.photon.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/georsstogeojson/GeoRSSToGeoJSON.js"
-                defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/heat/leaflet-heat.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/fullscreen/Leaflet.fullscreen.js"
-                defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/toolbar/leaflet.toolbar-src.js"
-                defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/formbuilder/Leaflet.FormBuilder.js"
-                defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/measurable/Leaflet.Measurable.js"
-                defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/togpx/togpx.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/iconlayers/iconLayers.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/tokml/tokml.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/locatecontrol/L.Control.Locate.js"
-                defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/dompurify/purify.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/colorbrewer/colorbrewer.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/vendors/simple-statistics/simple-statistics.min.js"
-                defer></script>
-{% endcompress %}
-{% if locale %}<script src="{{ STATIC_URL }}umap/locale/{{ locale }}.js" defer></script>{% endif %}
-{% compress js %}
-        <script src="{{ STATIC_URL }}umap/js/umap.core.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.autocomplete.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.popup.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.xhr.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.forms.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.icon.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.features.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.permissions.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.datalayer.permissions.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.layer.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.controls.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.slideshow.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.tableeditor.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.browser.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.importer.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.share.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/umap.ui.js" defer></script>
-        <script src="{{ STATIC_URL }}umap/js/components/fragment.js" defer></script>
-{% endcompress %}
+{% load static %}
+
+<script type="module" src="{% static 'umap/js/modules/global.js' %}" defer></script>
+<script src="{% static 'umap/vendors/editable/Path.Drag.js' %}" defer></script>
+<script src="{% static 'umap/vendors/editable/Leaflet.Editable.js' %}" defer></script>
+<script src="{% static 'umap/vendors/hash/leaflet-hash.js' %}" defer></script>
+<script src="{% static 'umap/vendors/i18n/Leaflet.i18n.js' %}" defer></script>
+<script src="{% static 'umap/vendors/editinosm/Leaflet.EditInOSM.js' %}" defer></script>
+<script src="{% static 'umap/vendors/minimap/Control.MiniMap.js' %}" defer></script>
+<script src="{% static 'umap/vendors/csv2geojson/csv2geojson.js' %}" defer></script>
+<script src="{% static 'umap/vendors/togeojson/togeojson.js' %}" defer></script>
+<script src="{% static 'umap/vendors/osmtogeojson/osmtogeojson.js' %}" defer></script>
+<script src="{% static 'umap/vendors/loading/Control.Loading.js' %}" defer></script>
+<script src="{% static 'umap/vendors/markercluster/leaflet.markercluster-src.js' %}" defer></script>
+<script src="{% static 'umap/vendors/contextmenu/leaflet.contextmenu.js' %}" defer></script>
+<script src="{% static 'umap/vendors/photon/leaflet.photon.js' %}" defer></script>
+<script src="{% static 'umap/vendors/georsstogeojson/GeoRSSToGeoJSON.js' %}" defer></script>
+<script src="{% static 'umap/vendors/heat/leaflet-heat.js' %}" defer></script>
+<script src="{% static 'umap/vendors/fullscreen/Leaflet.fullscreen.js' %}" defer></script>
+<script src="{% static 'umap/vendors/toolbar/leaflet.toolbar-src.js' %}" defer></script>
+<script src="{% static 'umap/vendors/formbuilder/Leaflet.FormBuilder.js' %}" defer></script>
+<script src="{% static 'umap/vendors/measurable/Leaflet.Measurable.js' %}" defer></script>
+<script src="{% static 'umap/vendors/togpx/togpx.js' %}" defer></script>
+<script src="{% static 'umap/vendors/iconlayers/iconLayers.js' %}" defer></script>
+<script src="{% static 'umap/vendors/tokml/tokml.js' %}" defer></script>
+<script src="{% static 'umap/vendors/locatecontrol/L.Control.Locate.js' %}" defer></script>
+<script src="{% static 'umap/vendors/dompurify/purify.js' %}" defer></script>
+<script src="{% static 'umap/vendors/colorbrewer/colorbrewer.js' %}" defer></script>
+<script src="{% static 'umap/vendors/simple-statistics/simple-statistics.min.js' %}" defer></script>
+{% if locale %}<script src="{% static 'umap/locale/fr.js' %}" defer></script>{% endif %}{# TODO: handle dynamic locale! #}
+<script src="{% static 'umap/js/umap.core.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.autocomplete.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.popup.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.xhr.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.forms.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.icon.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.features.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.permissions.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.datalayer.permissions.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.layer.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.controls.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.slideshow.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.tableeditor.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.browser.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.importer.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.share.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.js' %}" defer></script>
+<script src="{% static 'umap/js/umap.ui.js' %}" defer></script>
+<script src="{% static 'umap/js/components/fragment.js' %}" defer></script>

--- a/umap/templates/umap/map_detail.html
+++ b/umap/templates/umap/map_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load umap_tags compress i18n %}
+{% load umap_tags i18n %}
 {% block head_title %}
   {{ map.name }} - {{ SITE_NAME }}
 {% endblock head_title %}
@@ -7,9 +7,7 @@
   map_detail
 {% endblock body_class %}
 {% block extra_head %}
-  {% compress css %}
-    {% umap_css %}
-  {% endcompress %}
+  {% umap_css %}
   {% umap_js locale=locale %}
   {% if object.share_status != object.PUBLIC %}<meta name="robots" content="noindex">{% endif %}
 {% endblock extra_head %}

--- a/umap/tests/integration/test_statics.py
+++ b/umap/tests/integration/test_statics.py
@@ -1,0 +1,43 @@
+import re
+import shutil
+import tempfile
+
+import pytest
+from django.core.management import call_command
+from django.utils.translation import override
+from playwright.sync_api import expect
+
+
+@pytest.fixture
+def staticfiles(settings):
+    static_root = tempfile.mkdtemp(prefix="test_static")
+    settings.STATIC_ROOT = static_root
+    try:
+        call_command("collectstatic", "--noinput")
+        yield
+    finally:
+        shutil.rmtree(static_root)
+
+
+def test_javascript_have_been_loaded(
+    map, live_server, datalayer, page, settings, staticfiles
+):
+    settings.STORAGES["staticfiles"][
+        "BACKEND"
+    ] = "umap.utils.UmapManifestStaticFilesStorage"
+    datalayer.settings["displayOnLoad"] = False
+    datalayer.save()
+    map.settings["properties"]["defaultView"] = "latest"
+    map.save()
+    with override("fr"):
+        url = f"{live_server.url}{map.get_absolute_url()}"
+        assert "/fr/" in url
+        page.goto(url)
+    # Hash is defined, so map is initialized
+    expect(page).to_have_url(re.compile(r".*#7/48\..+/13\..+"))
+    expect(page).to_have_url(re.compile(r".*/fr/"))
+    # Should be in French, so hashed locale file has been loaded correctly
+    button = page.get_by_text("Voir les calques")
+    expect(button).to_be_visible()
+    layers = page.locator(".umap-browse-datalayers li")
+    expect(layers).to_have_count(1)

--- a/umap/tests/settings.py
+++ b/umap/tests/settings.py
@@ -3,7 +3,6 @@ import os
 from umap.settings.base import *  # pylint: disable=W0614,W0401
 
 SECRET_KEY = "justfortests"
-COMPRESS_ENABLED = False
 FROM_EMAIL = "test@test.org"
 EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 

--- a/umap/tests/settings.py
+++ b/umap/tests/settings.py
@@ -5,6 +5,9 @@ from umap.settings.base import *  # pylint: disable=W0614,W0401
 SECRET_KEY = "justfortests"
 FROM_EMAIL = "test@test.org"
 EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+STORAGES["staticfiles"][
+    "BACKEND"
+] = "django.contrib.staticfiles.storage.StaticFilesStorage"
 
 if os.environ.get("GITHUB_ACTIONS", False) == "true":
     DATABASES = {


### PR DESCRIPTION
This is a really early stage.

* [x] Deal with the commented `favicon.ico` which tries to reach `staticfiles_storage.url("umap/favicons/favicon.ico")`
* [x] Check that all paths are well rewritten
* [x] Handle [dynamic {locale}.js path](https://github.com/umap-project/umap/pull/1539/files#diff-b642b030e74563d2d5e096cdb16de5c85eb02fb18191734f8995a4fa51246212R30), not sure how it can work, maybe with intermediary variable?
* [x] Fix tests :)

The `support_js_module_import_aggregation` toggle + wrong regexps for our prettier semicolons-less config were hard to find!