### PR TITLE
fix: do not ask more classes than available values in choropleth mode

### DIFF
--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -194,6 +194,7 @@ L.U.Layer.Choropleth = L.FeatureGroup.extend({
     let mode = this.datalayer.options.choropleth.mode,
       classes = +this.datalayer.options.choropleth.classes || 5,
       breaks
+    classes = Math.min(classes, values.length)
     if (mode === 'manual') {
       const manualBreaks = this.datalayer.options.choropleth.breaks
       if (manualBreaks) {


### PR DESCRIPTION
It actually does not make sense, and it's a sanity check: some computation algorithms fail in this situation.