### PR TITLE
fix: do not try to reset tooltip of feature not on map

### DIFF
--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -794,8 +794,10 @@ L.U.PathMixin = {
   },
 
   _redraw: function () {
-    this.setStyle()
-    this.resetTooltip()
+    if (this.datalayer && this.datalayer.isVisible()) {
+      this.setStyle()
+      this.resetTooltip()
+    }
   },
 
   onAdd: function (map) {


### PR DESCRIPTION
This can happen in a situation where:
- a layer as zoom limits
- we click on a feature, which opens a popup
- then zoom over the layer's limit (with scroll or keyboard, not keyboard, in order to not close the popup)
- then click in anywhere in the map, which will close the popup

Since the highlight of features on click (cf #1359), we redraw them on popupclose, which explains the bug described above.

fix #1575