### PR TITLE
feat: allow to set zoomTo from query string

### DIFF
--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -27,6 +27,10 @@ L.Util.setBooleanFromQueryString = (options, name) => {
   const value = L.Util.queryString(name)
   if (typeof value !== 'undefined') options[name] = value == '1' || value == 'true'
 }
+L.Util.setNumberFromQueryString = (options, name) => {
+  const value = +L.Util.queryString(name)
+  if (!isNaN(value)) options[name] = value
+}
 L.Util.setNullableBooleanFromQueryString = (options, name) => {
   let value = L.Util.queryString(name)
   if (typeof value !== 'undefined') {

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -86,16 +86,16 @@ U.Map = L.Map.extend({
     popupShape: String,
     popupTemplate: String,
     popupContentTemplate: String,
-    zoomTo: undefined,
+    zoomTo: Number,
     captionBar: Boolean,
     captionMenus: Boolean,
     slideshow: undefined,
     sortKey: undefined,
-    labelKey: undefined,
+    labelKey: String,
     filterKey: undefined,
     facetKey: undefined,
     slugKey: undefined,
-    showLabel: undefined,
+    showLabel: 'NullableBoolean',
     labelDirection: undefined,
     labelInteractive: undefined,
     outlinkTarget: undefined,
@@ -342,8 +342,12 @@ U.Map = L.Map.extend({
         case 'NullableBoolean':
           L.Util.setNullableBooleanFromQueryString(options, key)
           break
+        case Number:
+          L.Util.setNumberFromQueryString(options, key)
+          break
         case String:
           L.Util.setFromQueryString(options, key)
+          break
       }
     }
     // Specific case for datalayersControl

--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -1458,7 +1458,10 @@ U.DataLayer = L.Evented.extend({
   zoomTo: function () {
     if (!this.isVisible()) return
     const bounds = this.layer.getBounds()
-    if (bounds.isValid()) this.map.fitBounds(bounds)
+    if (bounds.isValid()) {
+      const options = {maxZoom: this.getOption("zoomTo")}
+      this.map.fitBounds(bounds, options)
+    }
   },
 
   // Is this layer type browsable in theorie


### PR DESCRIPTION
When using data/dataUrl querystring, uMap will import data at load, and will set view using this data bounds. In some situation (Deveco), the user wants to control the max zoom of the final view.

Also add labelKey and showLabel to be parsed from query string, still for Deveco needs.