### PR TITLE
feat: change breakpoint to switch black SVG img to white

### DIFF
--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -410,7 +410,8 @@ L.DomUtil.contrastedColor = (el, bgcolor) => {
   rgb = L.DomUtil.RGBRegex.exec(rgb)
   if (!rgb || rgb.length !== 4) return out
   rgb = parseInt(rgb[1], 10) + parseInt(rgb[2], 10) + parseInt(rgb[3], 10)
-  if (rgb < (255 * 3) / 2) out = 1
+  const threshold = 140
+  if (rgb < threshold * 3) out = 1
   if (bgcolor) _CACHE_CONSTRAST[bgcolor] = out
   return out
 }

--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -396,10 +396,28 @@ L.DomUtil.after = (target, el) => {
   return el
 }
 
+// From https://gist.github.com/Accudio/b9cb16e0e3df858cef0d31e38f1fe46f
+// convert colour in range 0-255 to the modifier used within luminance calculation
+L.DomUtil.colourMod = (colour) => {
+  const sRGB = colour / 255
+  let mod = Math.pow((sRGB + 0.055) / 1.055, 2.4)
+  if (sRGB < 0.03928) mod = sRGB / 12.92
+  return mod
+}
 L.DomUtil.RGBRegex = /rgb *\( *([0-9]{1,3}) *, *([0-9]{1,3}) *, *([0-9]{1,3}) *\)/
 L.DomUtil.TextColorFromBackgroundColor = (el, bgcolor) => {
   return L.DomUtil.contrastedColor(el, bgcolor) ? '#ffffff' : '#000000'
 }
+L.DomUtil.contrastWCAG21 = (rgb) => {
+  const [r, g, b] = rgb
+  // luminance of inputted colour
+  const lum = 0.2126 * L.DomUtil.colourMod(r) + 0.7152 * L.DomUtil.colourMod(g) + 0.0722 * L.DomUtil.colourMod(b)
+  // white has a luminance of 1
+  const whiteLum = 1
+  const contrast = (whiteLum + 0.05) / (lum + 0.05)
+  return contrast > 3 ? 1 : 0
+}
+
 const _CACHE_CONSTRAST = {}
 L.DomUtil.contrastedColor = (el, bgcolor) => {
   // Return 0 for black and 1 for white
@@ -409,9 +427,8 @@ L.DomUtil.contrastedColor = (el, bgcolor) => {
   let rgb = window.getComputedStyle(el).getPropertyValue('background-color')
   rgb = L.DomUtil.RGBRegex.exec(rgb)
   if (!rgb || rgb.length !== 4) return out
-  rgb = parseInt(rgb[1], 10) + parseInt(rgb[2], 10) + parseInt(rgb[3], 10)
-  const threshold = 140
-  if (rgb < threshold * 3) out = 1
+  rgb = [parseInt(rgb[1], 10), parseInt(rgb[2], 10), parseInt(rgb[3], 10)]
+  out = L.DomUtil.contrastWCAG21(rgb)
   if (bgcolor) _CACHE_CONSTRAST[bgcolor] = out
   return out
 }


### PR DESCRIPTION
I've been a report about changed pictograms, which pointed to this map:

![image](https://github.com/umap-project/umap/assets/146023/75e67802-144e-4525-bb04-da360bee4d9d)

I found that with those grey, the picto should have been white, so I had a look and increased a bit the threshold.

Before:
![Screenshot from 2024-02-12 12-42-02](https://github.com/umap-project/umap/assets/146023/aea53049-ba36-4a09-855d-6aca563e9f1d)

After:
![Screenshot from 2024-02-12 12-41-49](https://github.com/umap-project/umap/assets/146023/28ae6eca-d68e-45bd-8ecd-4daf3646e1f0)
