### PR TITLE
feat: show last used pictograms in a separate tab

### DIFF
--- a/umap/static/umap/js/umap.icon.js
+++ b/umap/static/umap/js/umap.icon.js
@@ -1,6 +1,6 @@
 U.Icon = L.DivIcon.extend({
   statics: {
-    LAST_USED: [],
+    RECENT: [],
   },
   initialize: function (map, options) {
     this.map = map
@@ -17,11 +17,11 @@ U.Icon = L.DivIcon.extend({
     }
   },
 
-  _setLastUsed: function (url) {
+  _setRecent: function (url) {
     if (L.Util.hasVar(url)) return
-    if (url === this.map.options.default_iconUrl) return
-    if (U.Icon.LAST_USED.indexOf(url) === -1) {
-      U.Icon.LAST_USED.push(url)
+    if (url === U.DEFAULT_ICON_URL) return
+    if (U.Icon.RECENT.indexOf(url) === -1) {
+      U.Icon.RECENT.push(url)
     }
   },
 
@@ -29,7 +29,7 @@ U.Icon = L.DivIcon.extend({
     let url
     if (this.feature && this.feature._getIconUrl(name)) {
       url = this.feature._getIconUrl(name)
-      this._setLastUsed(url)
+      this._setRecent(url)
     } else {
       url = this.options[`${name}Url`]
     }

--- a/umap/static/umap/js/umap.icon.js
+++ b/umap/static/umap/js/umap.icon.js
@@ -1,4 +1,7 @@
 U.Icon = L.DivIcon.extend({
+  statics: {
+    LAST_USED: [],
+  },
   initialize: function (map, options) {
     this.map = map
     const default_options = {
@@ -14,11 +17,22 @@ U.Icon = L.DivIcon.extend({
     }
   },
 
+  _setLastUsed: function (url) {
+    if (L.Util.hasVar(url)) return
+    if (url === this.map.options.default_iconUrl) return
+    if (U.Icon.LAST_USED.indexOf(url) === -1) {
+      U.Icon.LAST_USED.push(url)
+    }
+  },
+
   _getIconUrl: function (name) {
     let url
-    if (this.feature && this.feature._getIconUrl(name))
+    if (this.feature && this.feature._getIconUrl(name)) {
       url = this.feature._getIconUrl(name)
-    else url = this.options[`${name}Url`]
+      this._setLastUsed(url)
+    } else {
+      url = this.options[`${name}Url`]
+    }
     return this.formatUrl(url, this.feature)
   },
 
@@ -216,7 +230,7 @@ U.Icon.setIconContrast = function (icon, parent, src, bgcolor) {
    * src: the raw "icon" value, can be an URL, a path, text, emoticon, etc.
    * bgcolor: the background color, used for caching and in case we cannot guess the
    * parent background color
-  */
+   */
   if (!icon) return
 
   if (L.DomUtil.contrastedColor(parent, bgcolor)) {

--- a/umap/tests/integration/test_picto.py
+++ b/umap/tests/integration/test_picto.py
@@ -58,6 +58,8 @@ def test_can_change_picto_at_map_level(map, live_server, page, pictos):
     expect(define).to_be_visible()
     expect(undefine).to_be_hidden()
     define.click()
+    # No picto defined yet, so recent should not be visible
+    expect(page.get_by_text("Recent")).to_be_hidden()
     symbols = page.locator(".umap-pictogram-choice")
     expect(symbols).to_have_count(2)
     search = page.locator(".umap-pictogram-body input")
@@ -93,8 +95,14 @@ def test_can_change_picto_at_datalayer_level(map, live_server, page, pictos):
     expect(define).to_be_visible()
     expect(undefine).to_be_hidden()
     define.click()
+    # Map has an icon defined, so it shold open on Recent tab
     symbols = page.locator(".umap-pictogram-choice")
-    expect(symbols).to_have_count(3)
+    expect(page.get_by_text("Recent")).to_be_visible()
+    expect(symbols).to_have_count(1)
+    symbol_tab = page.get_by_role("button", name="Symbol")
+    expect(symbol_tab).to_be_visible()
+    symbol_tab.click()
+    expect(symbols).to_have_count(2)
     search = page.locator(".umap-pictogram-body input")
     search.type("circle")
     expect(symbols).to_have_count(1)
@@ -127,8 +135,14 @@ def test_can_change_picto_at_marker_level(map, live_server, page, pictos):
     expect(define).to_be_visible()
     expect(undefine).to_be_hidden()
     define.click()
+    # Map has an icon defined, so it shold open on Recent tab
     symbols = page.locator(".umap-pictogram-choice")
-    expect(symbols).to_have_count(3)  # Include "Last used" picto
+    expect(page.get_by_text("Recent")).to_be_visible()
+    expect(symbols).to_have_count(1)
+    symbol_tab = page.get_by_role("button", name="Symbol")
+    expect(symbol_tab).to_be_visible()
+    symbol_tab.click()
+    expect(symbols).to_have_count(2)
     search = page.locator(".umap-pictogram-body input")
     search.type("circle")
     expect(symbols).to_have_count(1)
@@ -157,10 +171,6 @@ def test_can_use_remote_url_as_picto(map, live_server, page, pictos):
     define = page.locator(".umap-field-iconUrl .define")
     expect(define).to_be_visible()
     define.click()
-    expect(page.get_by_text("Used in this map")).to_be_hidden()
-    # Only default symbols
-    symbols = page.locator(".umap-pictogram-choice")
-    expect(symbols).to_have_count(2)
     url_tab = page.get_by_role("button", name="URL")
     input_el = page.get_by_placeholder("Add image URL")
     expect(input_el).to_be_hidden()
@@ -179,13 +189,10 @@ def test_can_use_remote_url_as_picto(map, live_server, page, pictos):
     modify = page.locator(".umap-field-iconUrl").get_by_text("Change")
     expect(modify).to_be_visible()
     modify.click()
-    # Should be on URL tab
-    expect(input_el).to_be_visible()
-    # Symbol should be visible in symbols b
-    symbols_tab = page.get_by_role("button", name="Symbol")
-    symbols_tab.click()
-    expect(page.get_by_text("Used in this map")).to_be_visible()
-    expect(symbols).to_have_count(3)
+    # Should be on Recent tab
+    symbols = page.locator(".umap-pictogram-choice")
+    expect(page.get_by_text("Recent")).to_be_visible()
+    expect(symbols).to_have_count(1)
 
 
 def test_can_use_char_as_picto(map, live_server, page, pictos):
@@ -225,4 +232,6 @@ def test_can_use_char_as_picto(map, live_server, page, pictos):
     expect(preview).to_be_visible()
     preview.click()
     # Should be on URL tab
-    expect(input_el).to_be_visible()
+    symbols = page.locator(".umap-pictogram-choice")
+    expect(page.get_by_text("Recent")).to_be_visible()
+    expect(symbols).to_have_count(1)

--- a/umap/tests/integration/test_picto.py
+++ b/umap/tests/integration/test_picto.py
@@ -94,7 +94,7 @@ def test_can_change_picto_at_datalayer_level(map, live_server, page, pictos):
     expect(undefine).to_be_hidden()
     define.click()
     symbols = page.locator(".umap-pictogram-choice")
-    expect(symbols).to_have_count(2)
+    expect(symbols).to_have_count(3)
     search = page.locator(".umap-pictogram-body input")
     search.type("circle")
     expect(symbols).to_have_count(1)
@@ -128,7 +128,7 @@ def test_can_change_picto_at_marker_level(map, live_server, page, pictos):
     expect(undefine).to_be_hidden()
     define.click()
     symbols = page.locator(".umap-pictogram-choice")
-    expect(symbols).to_have_count(2)
+    expect(symbols).to_have_count(3)  # Include "Last used" picto
     search = page.locator(".umap-pictogram-body input")
     search.type("circle")
     expect(symbols).to_have_count(1)
@@ -157,6 +157,10 @@ def test_can_use_remote_url_as_picto(map, live_server, page, pictos):
     define = page.locator(".umap-field-iconUrl .define")
     expect(define).to_be_visible()
     define.click()
+    expect(page.get_by_text("Used in this map")).to_be_hidden()
+    # Only default symbols
+    symbols = page.locator(".umap-pictogram-choice")
+    expect(symbols).to_have_count(2)
     url_tab = page.get_by_role("button", name="URL")
     input_el = page.get_by_placeholder("Add image URL")
     expect(input_el).to_be_hidden()
@@ -177,6 +181,11 @@ def test_can_use_remote_url_as_picto(map, live_server, page, pictos):
     modify.click()
     # Should be on URL tab
     expect(input_el).to_be_visible()
+    # Symbol should be visible in symbols b
+    symbols_tab = page.get_by_role("button", name="Symbol")
+    symbols_tab.click()
+    expect(page.get_by_text("Used in this map")).to_be_visible()
+    expect(symbols).to_have_count(3)
 
 
 def test_can_use_char_as_picto(map, live_server, page, pictos):


### PR DESCRIPTION
This feature was planned in the initial rework of the pictogram form UI, but not yet done. Some recent discussion in the OSM French forum reactivated the need for it.

cf https://forum.openstreetmap.fr/t/marker-and-marker-colors/21051

![image](https://github.com/umap-project/umap/assets/146023/225072a3-9258-4971-ab48-f01b230c86fd)
