### PR TITLE
fix: encode the whole url parameter for OEmbed

### DIFF
--- a/umap/templates/umap/map_detail.html
+++ b/umap/templates/umap/map_detail.html
@@ -17,7 +17,7 @@
   {% umap_js locale=locale %}
   {% if object.share_status != object.PUBLIC %}<meta name="robots" content="noindex">{% endif %}
   <link rel="alternate" type="application/json+oembed"
-    href="{{ oembed_absolute_uri }}?url={{ absolute_uri|urlencode }}&format=json"
+    href="{{ oembed_absolute_uri }}?url={{ quoted_absolute_uri }}&format=json"
     title="{{ map.name }} oEmbed URL" />
 {% endblock extra_head %}
 {% block content %}

--- a/umap/tests/test_map_views.py
+++ b/umap/tests/test_map_views.py
@@ -775,6 +775,15 @@ def test_oembed_no_url_map(client, map, datalayer):
     assert response.status_code == 404
 
 
+def test_oembed_unknown_url_map(client, map, datalayer):
+    map_url = f"http://testserver{map.get_absolute_url()}"
+    # We change to an unknown id prefix to keep URL structure.
+    map_url = map_url.replace("map_", "_111")
+    url = f"{reverse('map_oembed')}?url={map_url}"
+    response = client.get(url)
+    assert response.status_code == 404
+
+
 def test_oembed_wrong_format_map(client, map, datalayer):
     url = (
         f"{reverse('map_oembed')}"

--- a/umap/tests/test_map_views.py
+++ b/umap/tests/test_map_views.py
@@ -815,6 +815,6 @@ def test_oembed_link(client, map, datalayer):
     )
     assert (
         'href="http://testserver/map/oembed/'
-        f'?url=http%3A//testserver/en/map/test-map_{map.id}&format=json"'
+        f'?url=http%3A%2F%2Ftestserver%2Fen%2Fmap%2Ftest-map_{map.id}&format=json"'
     ) in response.content.decode()
     assert 'title="test map oEmbed URL" />' in response.content.decode()

--- a/umap/views.py
+++ b/umap/views.py
@@ -10,7 +10,7 @@ from http.client import InvalidURL
 from io import BytesIO
 from pathlib import Path
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, quote_plus, urlparse
 from urllib.request import Request, build_opener
 
 from django.conf import settings
@@ -595,8 +595,8 @@ class MapView(MapDetailMixin, PermissionsMixin, DetailView):
         context["oembed_absolute_uri"] = self.request.build_absolute_uri(
             reverse("map_oembed")
         )
-        context["absolute_uri"] = self.request.build_absolute_uri(
-            self.object.get_absolute_url()
+        context["quoted_absolute_uri"] = quote_plus(
+            self.request.build_absolute_uri(self.object.get_absolute_url())
         )
         return context
 

--- a/umap/views.py
+++ b/umap/views.py
@@ -695,7 +695,7 @@ class MapOEmbed(View):
         if "slug" not in kwargs or "map_id" not in kwargs:
             raise Http404("Invalid URL path.")
 
-        map_ = Map.objects.get(id=kwargs["map_id"], slug=kwargs["slug"])
+        map_ = get_object_or_404(Map, id=kwargs["map_id"])
 
         if map_.share_status != Map.PUBLIC:
             raise PermissionDenied("This map is not public.")


### PR DESCRIPTION
See https://github.com/umap-project/umap/pull/1526#issuecomment-1937040472

I'm not fully sure it'll fix the issue though.