### PR TITLE
fix: custom storage for tests

### DIFF
--- a/umap/storage.py
+++ b/umap/storage.py
@@ -56,3 +56,7 @@ class UmapManifestStaticFilesStorage(ManifestStaticFilesStorage):
                     minified = cssmin(initial)
                     path.write_text(minified)
             yield original_path, processed_path, True
+
+
+class UmapManifestStaticFilesStorageNotStrict(UmapManifestStaticFilesStorage):
+    manifest_strict = False

--- a/umap/tests/integration/test_statics.py
+++ b/umap/tests/integration/test_statics.py
@@ -24,7 +24,7 @@ def test_javascript_have_been_loaded(
 ):
     settings.STORAGES["staticfiles"][
         "BACKEND"
-    ] = "umap.storage.UmapManifestStaticFilesStorage"
+    ] = "umap.storage.UmapManifestStaticFilesStorageNotStrict"
     datalayer.settings["displayOnLoad"] = False
     datalayer.save()
     map.settings["properties"]["defaultView"] = "latest"


### PR DESCRIPTION
Setting `manifest_strict = False` will hopefully get rid of issues we have with the CI:

> ValueError: Missing staticfiles manifest entry for 'umap/favicons/icon-192.png'

See https://docs.djangoproject.com/en/5.0/ref/contrib/staticfiles/#django.contrib.staticfiles.storage.ManifestStaticFilesStorage.manifest_strict