### PR TITLE
Switch license from WTFPL to AGPLv3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,13 +1,16 @@
-            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-                    Version 2, December 2004
+uMap lets you create maps with OpenStreetMap layers in a minute.
+Copyright (C) 2024 Yohan Boniface <yb@enix.org> & contributors
+https://github.com/umap-project/umap/graphs/contributors
 
- Copyright (C) 2013 Yohan Boniface <yb@enix.org>
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
- Everyone is permitted to copy and distribute verbatim or modified
- copies of this license document, and changing it is allowed as long
- as the name is changed.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
-            DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE
-   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
-
-  0. You just DO WHAT THE FUCK YOU WANT TO. 
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
Rationale: the WTFPL is not an OSI approved license since it has been rejected as such in 2009 (emphase is mine):

> Title: WTFPL Submission: http://crynwr.com/cgi-bin/ezmlm-cgi?17:mss:634:200902:aglgcgbhmfcheffmdgon License: http://sam.zoy.org/wtfpl/ Comments: It’s no different from dedication to the public domain. Author has submitted license approval request — author is free to make public domain dedication. Although he agrees with the recommendation, Mr. Michlmayr notes that **public domain doesn’t exist in Europe.** Recommend: Reject — https://opensource.org/meeting-minutes/minutes20090304/

This is an issue to be able to apply to some open-source programs and grants.
