### PR TITLE
chore: remove duplicate "map updated" message

### DIFF
--- a/umap/views.py
+++ b/umap/views.py
@@ -776,7 +776,6 @@ class MapUpdate(FormLessEditMixin, PermissionsMixin, UpdateView):
             id=self.object.pk,
             url=self.object.get_absolute_url(),
             permissions=self.get_permissions(),
-            info=_("Map has been updated!"),
         )
 
 


### PR DESCRIPTION
It is already handled by the front-end, and as it also handle the "map created" message (including anonymous link form), I arbitrated to keep all front-end side