### PR TITLE
fix: do not try to animate the panel

### DIFF
--- a/umap/static/umap/js/umap.popup.js
+++ b/umap/static/umap/js/umap.popup.js
@@ -96,6 +96,7 @@ U.Popup.Panel = U.Popup.extend({
   _updateLayout: function () {},
   _updatePosition: function () {},
   _adjustPan: function () {},
+  _animateZoom: function () {},
 })
 U.Popup.SimplePanel = U.Popup.Panel // Retrocompat.
 


### PR DESCRIPTION
The panel inherits from the classic Popup, but given it's fixed on the UI, it does not make sense to try to move it, and it some situation there is a race condition that make Leaflet try to animate but this fails