### PR TITLE
chore: raise error if any in storage post_process

### DIFF
--- a/umap/storage.py
+++ b/umap/storage.py
@@ -41,8 +41,9 @@ class UmapManifestStaticFilesStorage(ManifestStaticFilesStorage):
     def post_process(self, paths, **options):
         collected = super().post_process(paths, **options)
         for original_path, processed_path, processed in collected:
-            if not processed_path:
-                print("Unused or missing file?", original_path)
+            if isinstance(processed, Exception):
+                print("Error with file", original_path)
+                raise processed
             if processed_path.endswith(".js"):
                 path = Path(settings.STATIC_ROOT) / processed_path
                 initial = path.read_text()


### PR DESCRIPTION
I'm not totally sure it's the way to go (maybe ignoring here is fine ?), but it seems still more usefull to have a proper error instead of a python error a few lines forward.