### PR TITLE
fix: picto category title was added after the related pictograms

### DIFF
--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -672,9 +672,9 @@ L.FormBuilder.IconUrl = L.FormBuilder.BlurInput.extend({
   },
 
   addCategory: function (items, name) {
-    const parent = L.DomUtil.create('div', 'umap-pictogram-category'),
-      grid = L.DomUtil.create('div', 'umap-pictogram-grid', parent)
+    const parent = L.DomUtil.create('div', 'umap-pictogram-category')
     if (name) L.DomUtil.add('h6', '', parent, name)
+    const grid = L.DomUtil.create('div', 'umap-pictogram-grid', parent)
     let status = false
     for (let item of items) {
       status = this.addIconPreview(item, grid) || status


### PR DESCRIPTION
Before:
![image](https://github.com/umap-project/umap/assets/146023/557a352b-8382-4047-9e8b-254b7c1ebe10)

After:
![image](https://github.com/umap-project/umap/assets/146023/194d3529-8b3e-4324-ba11-17ae2a3d7a83)
