### PR TITLE
a11y: use role=alert for messages from Django and JS

### DIFF
--- a/umap/static/umap/alerts.css
+++ b/umap/static/umap/alerts.css
@@ -1,0 +1,34 @@
+[data-alert] {
+    box-sizing: border-box;
+    min-height: 46px;
+    line-height: 46px;
+    padding-left: 10px;
+    width: calc(100% - 500px);
+    position: absolute;
+    left: 250px;  /* Keep save/cancel button accessible. */
+    right: 250px;
+    box-shadow: 0 1px 7px #999999;
+    background: none repeat scroll 0 0 rgba(20, 22, 23, 0.8);
+    font-weight: bold;
+    color: #fff;
+    font-size: 0.8em;
+    z-index: 1012;
+    border-radius: 2px;
+    visibility: visible;
+    top: 23px;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+[data-alert][data-level="error"] {
+    background-color: #c60f13;
+}
+[data-alert] [data-close] {
+    color: #fff;
+    padding-right: 10px;
+    width: 100px;
+    line-height: 1;
+    margin: .5rem;
+    background-color: #202425;
+    font-size: .7rem;
+}

--- a/umap/static/umap/js/modules/alerts.js
+++ b/umap/static/umap/js/modules/alerts.js
@@ -1,0 +1,54 @@
+export default class Alerts {
+  constructor() {
+    this.alertNode = document.querySelector('[role="alert"]')
+    const observer = new MutationObserver(this._callback.bind(this))
+    observer.observe(this.alertNode, { childList: true })
+    // On initial page load, we want to display messages from Django.
+    Array.from(this.alertNode.children).forEach(this._display.bind(this))
+  }
+
+  _callback(mutationList, observer) {
+    for (const mutation of mutationList) {
+      this._display(
+        [...mutation.addedNodes].filter((item) => item.tagName === 'P').pop()
+      )
+    }
+  }
+
+  _display(alert) {
+    const duration = alert.dataset?.duration || 3000
+    const level = alert.dataset?.level || 'info'
+    const wrapper = document.createElement('div')
+    const alertHTML = alert.cloneNode(true).outerHTML
+    wrapper.innerHTML = `
+    <div data-level="${level}" data-alert data-toclose>
+      ${alertHTML}
+      <button class="umap-close-link" type="button" data-close>
+        <i class="umap-close-icon"></i><span>${L._('Close')}</span>
+      </button>
+    </div>
+    `
+    const alertDiv = wrapper.firstElementChild
+    this.alertNode.after(alertDiv)
+    if (isFinite(duration)) {
+      setTimeout(() => {
+        alertDiv.remove()
+      }, duration)
+    }
+  }
+
+  add(message, level = 'info', duration = 3000) {
+    this.alertNode.innerHTML = `
+      <p data-level="${level}" data-duration="${duration}">
+        ${message}
+      </p>
+    `
+  }
+}
+
+// TODISCUSS: this might be something we want somewhere else.
+document.addEventListener('click', (event) => {
+  if (event.target.closest('[data-close]')) {
+    event.target.closest('[data-toclose]').remove()
+  }
+})

--- a/umap/static/umap/js/modules/global.js
+++ b/umap/static/umap/js/modules/global.js
@@ -1,5 +1,6 @@
 import * as L from '../../vendors/leaflet/leaflet-src.esm.js'
 import URLs from './urls.js'
+import Alerts from './alerts.js'
 import Browser from './browser.js'
 import { Request, ServerRequest, RequestError, HTTPError, NOKError } from './request.js'
 // Import modules and export them to the global scope.
@@ -7,4 +8,13 @@ import { Request, ServerRequest, RequestError, HTTPError, NOKError } from './req
 
 // Copy the leaflet module, it's expected by leaflet plugins to be writeable.
 window.L = { ...L }
-window.U = { URLs, Request, ServerRequest, RequestError, HTTPError, NOKError, Browser }
+window.U = {
+  Alerts,
+  URLs,
+  Request,
+  ServerRequest,
+  RequestError,
+  HTTPError,
+  NOKError,
+  Browser,
+}

--- a/umap/static/umap/js/modules/request.js
+++ b/umap/static/umap/js/modules/request.js
@@ -1,5 +1,6 @@
 // Uses `L._`` from Leaflet.i18n which we cannot import as a module yet
 import { DomUtil } from '../../vendors/leaflet/leaflet-src.esm.js'
+import Alert from './alerts.js'
 
 export class RequestError extends Error {}
 
@@ -50,6 +51,7 @@ export class Request extends BaseRequest {
   constructor(ui) {
     super()
     this.ui = ui
+    this.alerts = new Alert()
   }
 
   async _fetch(method, uri, headers, data) {
@@ -81,7 +83,7 @@ export class Request extends BaseRequest {
   }
 
   _onError(error) {
-    this.ui.alert({ content: L._('Problem in the response'), level: 'error' })
+    this.alerts.add(L._('Problem in the response'), 'error')
   }
 
   _onNOK(error) {
@@ -127,10 +129,10 @@ export class ServerRequest extends Request {
     try {
       const data = await response.json()
       if (data.info) {
-        this.ui.alert({ content: data.info, level: 'info' })
+        this.alerts.add(data.info)
         this.ui.closePanel()
       } else if (data.error) {
-        this.ui.alert({ content: data.error, level: 'error' })
+        this.alerts.add(data.error, 'error')
         return this._onError(new Error(data.error))
       }
       return [data, response, null]
@@ -145,10 +147,7 @@ export class ServerRequest extends Request {
 
   _onNOK(error) {
     if (error.status === 403) {
-      this.ui.alert({
-        content: message || L._('Action not allowed :('),
-        level: 'error',
-      })
+      this.alerts.add(message || L._('Action not allowed :('), 'error')
     }
     return [{}, error.response, error]
   }

--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -782,8 +782,7 @@ const ControlsMixin = {
         if (datalayer.hasDataVisible()) found = true
       })
       // TODO: display a results counter in the panel instead.
-      if (!found)
-        this.ui.alert({ content: L._('No results for these facets'), level: 'info' })
+      if (!found) this.alerts.add(L._('No results for these facets'))
     }
 
     const fields = keys.map((current) => [
@@ -1272,7 +1271,7 @@ U.Search = L.PhotonSearch.extend({
       if (latlng.isValid()) {
         this.reverse.doReverse(latlng)
       } else {
-        this.map.ui.alert({ content: 'Invalid latitude or longitude', mode: 'error' })
+        this.map.alerts.add(L._('Invalid latitude or longitude'), 'error')
       }
       return
     }

--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -686,10 +686,7 @@ U.Marker = L.Marker.extend({
     const builder = new U.FormBuilder(this, coordinatesOptions, {
       callback: function () {
         if (!this._latlng.isValid()) {
-          this.map.ui.alert({
-            content: L._('Invalid latitude or longitude'),
-            level: 'error',
-          })
+          this.map.alerts.add(L._('Invalid latitude or longitude'), 'error')
           builder.resetField('_latlng.lat')
           builder.resetField('_latlng.lng')
         }
@@ -886,7 +883,7 @@ U.PathMixin = {
     items.push({
       text: L._('Display measure'),
       callback: function () {
-        this.map.ui.alert({ content: this.getMeasure(), level: 'info' })
+        this.map.alerts.add(this.getMeasure())
       },
       context: this,
     })

--- a/umap/static/umap/js/umap.importer.js
+++ b/umap/static/umap/js/umap.importer.js
@@ -140,16 +140,15 @@ U.Importer = L.Class.extend({
         this.map.processFileToImport(file, layer, type)
       }
     } else {
-      if (!type)
-        return this.map.ui.alert({
-          content: L._('Please choose a format'),
-          level: 'error',
-        })
+      if (!type) {
+        this.map.alerts.add(L._('Please choose a format'), 'error')
+        return
+      }
       if (this.rawInput.value && type === 'umap') {
         try {
           this.map.importRaw(this.rawInput.value, type)
         } catch (e) {
-          this.ui.alert({ content: L._('Invalid umap data'), level: 'error' })
+          this.alerts.add(L._('Invalid umap data'), 'error')
           console.error(e)
         }
       } else {

--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -928,7 +928,7 @@ U.DataLayer = L.Evented.extend({
                 message: err[0].message,
               })
             }
-            this.map.ui.alert({ content: message, level: 'error', duration: 10000 })
+            this.map.alerts.add(message, 'error', 10000)
             console.error(err)
           }
           if (result && result.features.length) {
@@ -955,7 +955,7 @@ U.DataLayer = L.Evented.extend({
         const gj = JSON.parse(c)
         callback(gj)
       } catch (err) {
-        this.map.ui.alert({ content: `Invalid JSON file: ${err}` })
+        this.map.alerts.add(L._('Invalid JSON file: {error}', { error: err }), 'error')
         return
       }
     }
@@ -1013,12 +1013,12 @@ U.DataLayer = L.Evented.extend({
         return this.geojsonToFeatures(geometry.geometries)
 
       default:
-        this.map.ui.alert({
-          content: L._('Skipping unknown geometry.type: {type}', {
+        this.map.alerts.add(
+          L._('Skipping unknown geometry.type: {type}', {
             type: geometry.type || 'undefined',
           }),
-          level: 'error',
-        })
+          'error'
+        )
     }
     if (layer) {
       this.addLayer(layer)
@@ -1459,7 +1459,7 @@ U.DataLayer = L.Evented.extend({
     if (!this.isVisible()) return
     const bounds = this.layer.getBounds()
     if (bounds.isValid()) {
-      const options = {maxZoom: this.getOption("zoomTo")}
+      const options = { maxZoom: this.getOption('zoomTo') }
       this.map.fitBounds(bounds, options)
     }
   },

--- a/umap/static/umap/js/umap.permissions.js
+++ b/umap/static/umap/js/umap.permissions.js
@@ -53,10 +53,7 @@ U.MapPermissions = L.Class.extend({
   edit: function () {
     if (this.map.options.editMode !== 'advanced') return
     if (!this.map.options.umap_id)
-      return this.map.ui.alert({
-        content: L._('Please save the map first'),
-        level: 'info',
-      })
+      return this.map.alerts.add(L._('Please save the map first'))
     const container = L.DomUtil.create('div', 'permissions-panel'),
       fields = [],
       title = L.DomUtil.create('h3', '', container)
@@ -135,10 +132,7 @@ U.MapPermissions = L.Class.extend({
     const [data, response, error] = await this.map.server.post(this.getAttachUrl())
     if (!error) {
       this.options.owner = this.map.options.user
-      this.map.ui.alert({
-        content: L._('Map has been attached to your account'),
-        level: 'info',
-      })
+      this.map.alerts.add(L._('Map has been attached to your account'))
       this.map.ui.closePanel()
     }
   },

--- a/umap/static/umap/js/umap.tableeditor.js
+++ b/umap/static/umap/js/umap.tableeditor.js
@@ -83,10 +83,10 @@ U.TableEditor = L.Class.extend({
 
   validateName: function (name) {
     if (name.indexOf('.') !== -1) {
-      this.datalayer.map.ui.alert({
-        content: L._('Invalide property name: {name}', { name: name }),
-        level: 'error',
-      })
+      this.datalayer.map.alerts.add(
+        L._('Invalid property name: {name}', { name: name }),
+        'error'
+      )
       return false
     }
     return true

--- a/umap/static/umap/test/index.html
+++ b/umap/static/umap/test/index.html
@@ -64,6 +64,7 @@
 
     <link rel="stylesheet" href="../../umap/font.css" />
     <link rel="stylesheet" href="../../umap/base.css" />
+    <link rel="stylesheet" href="../../umap/alerts.css" />
     <link rel="stylesheet" href="../../umap/content.css" />
     <link rel="stylesheet" href="../../umap/nav.css" />
     <link rel="stylesheet" href="../../umap/map.css" />

--- a/umap/templates/umap/css.html
+++ b/umap/templates/umap/css.html
@@ -24,6 +24,7 @@
       href="{% static 'umap/vendors/iconlayers/iconLayers.css' %}" />
 <link rel="stylesheet" href="{% static 'umap/font.css' %}" />
 <link rel="stylesheet" href="{% static 'umap/base.css' %}" />
+<link rel="stylesheet" href="{% static 'umap/alerts.css' %}" />
 <link rel="stylesheet" href="{% static 'umap/content.css' %}" />
 <link rel="stylesheet" href="{% static 'umap/nav.css' %}" />
 <link rel="stylesheet" href="{% static 'umap/map.css' %}" />

--- a/umap/templates/umap/map_init.html
+++ b/umap/templates/umap/map_init.html
@@ -1,17 +1,16 @@
 {% load umap_tags %}
+
+<div role="alert">
+  {% for m in messages %}
+    {# We have just one, but we need to loop, as for messages API #}
+    <p data-level="{{ m.tags }}" data-duration="100000">{{ m }}</p>
+  {% endfor %}
+</div>
 <div id="map"></div>
 <!-- djlint:off -->
 <script defer type="text/javascript">
   window.addEventListener('DOMContentLoaded', (event) => {
     U.MAP = new U.Map("map", {{ map_settings|notag|safe }})
-    {% for m in messages %}
-      {# We have just one, but we need to loop, as for messages API #}
-      U.MAP.ui.alert({
-        content: "{{ m }}",
-        level: "{{ m.tags }}",
-        duration: 100000
-      })
-    {% endfor %}
   })
 </script>
 <!-- djlint:on -->

--- a/umap/templates/umap/messages.html
+++ b/umap/templates/umap/messages.html
@@ -1,5 +1,5 @@
 <div class="wrapper">
-  <div class="row">
+  <div class="row" role="alert">
     {% if messages %}
       <ul class="messages">
         {% for message in messages %}


### PR DESCRIPTION
Also define a custom module+css for alerts (chore).

This is an early stage, more a discussion at this point.
It works with messages from Django and set dynamically via JS.
The old code is still present.

See:
* https://www.w3.org/WAI/ARIA/apg/patterns/alert/
* https://www.w3.org/WAI/ARIA/apg/patterns/alert/examples/alert/
* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Alert_Role