### PR TITLE
fix: allow empty datalayers reference on merges.

### DIFF
--- a/umap/tests/integration/test_collaborative_editing.py
+++ b/umap/tests/integration/test_collaborative_editing.py
@@ -38,7 +38,7 @@ def test_collaborative_editing_create_markers(context, live_server, tilelayer):
 
     with page_one.expect_response(DATALAYER_UPDATE):
         save_p1.click()
-        # Prefent two layers to be saved on the same second, as we compare them based
+        # Prevent two layers to be saved on the same second, as we compare them based
         # on time in case of conflict. FIXME do not use time for comparison.
         sleep(1)
     assert DataLayer.objects.get(pk=datalayer.pk).settings == {
@@ -140,3 +140,59 @@ def test_collaborative_editing_create_markers(context, live_server, tilelayer):
         "permissions": {"edit_status": 1},
     }
     expect(marker_pane_p2).to_have_count(5)
+
+
+def test_empty_datalayers_can_be_merged(context, live_server, tilelayer):
+    # Let's create a new map with an empty datalayer
+    map = MapFactory(name="collaborative editing")
+    DataLayerFactory(map=map, edit_status=DataLayer.ANONYMOUS, data={})
+
+    # Open two tabs at the same time, on the same empty map
+    page_one = context.new_page()
+    page_one.goto(f"{live_server.url}{map.get_absolute_url()}?edit")
+
+    page_two = context.new_page()
+    page_two.goto(f"{live_server.url}{map.get_absolute_url()}?edit")
+
+    save_p1 = page_one.get_by_role("button", name="Save")
+    expect(save_p1).to_be_visible()
+
+    # Click on the Draw a marker button on a new map.
+    create_marker_p1 = page_one.get_by_title("Draw a marker")
+    expect(create_marker_p1).to_be_visible()
+    create_marker_p1.click()
+
+    # Check no marker is present by default.
+    marker_pane_p1 = page_one.locator(".leaflet-marker-pane > div")
+    expect(marker_pane_p1).to_have_count(0)
+
+    # Click on the map, it will place a marker at the given position.
+    map_el_p1 = page_one.locator("#map")
+    map_el_p1.click(position={"x": 200, "y": 200})
+    expect(marker_pane_p1).to_have_count(1)
+
+    with page_one.expect_response(DATALAYER_UPDATE):
+        save_p1.click()
+        sleep(1)
+
+    save_p2 = page_two.get_by_role("button", name="Save")
+    expect(save_p2).to_be_visible()
+
+    # Click on the Draw a marker button on a new map.
+    create_marker_p2 = page_two.get_by_title("Draw a marker")
+    expect(create_marker_p2).to_be_visible()
+    create_marker_p2.click()
+
+    marker_pane_p2 = page_two.locator(".leaflet-marker-pane > div")
+
+    # Click on the map, it will place a marker at the given position.
+    map_el_p2 = page_two.locator("#map")
+    map_el_p2.click(position={"x": 220, "y": 220})
+    expect(marker_pane_p2).to_have_count(1)
+
+    # Save p1 and p2 at the same time
+    with page_two.expect_response(DATALAYER_UPDATE):
+        save_p2.click()
+        sleep(1)
+
+    expect(marker_pane_p2).to_have_count(2)

--- a/umap/views.py
+++ b/umap/views.py
@@ -1076,7 +1076,9 @@ class DataLayerUpdate(FormLessEditMixin, GZipMixin, UpdateView):
 
         try:
             merged_features = merge_features(
-                reference["features"], latest["features"], entrant["features"]
+                reference.get("features", []),
+                latest.get("features", []),
+                entrant.get("features", []),
             )
             latest["features"] = merged_features
             return latest


### PR DESCRIPTION
Previously, an error was thrown when the reference datalayer had no `features`defined.

When looking for features, it now defaults to an empty list if the key doesn't exist.