### PR TITLE
fix: read id and @id as osm id in osm template

### DIFF
--- a/umap/static/umap/js/umap.popup.js
+++ b/umap/static/umap/js/umap.popup.js
@@ -324,7 +324,7 @@ U.PopupTemplate.OSM = U.PopupTemplate.Default.extend({
         L.DomUtil.element('a', { href: `mailto:${email}`, textContent: email })
       )
     }
-    const id = props['@id']
+    const id = props['@id'] || props['id']
     if (id) {
       L.DomUtil.add(
         'div',


### PR DESCRIPTION
cf #1663

Seems be something `id` sometime `@id`, not sure why (node vs relation ? old vs recent ?). Let's allow both, it's simpler than trying to understand :p