### PR TITLE
chore: ensure merge + assigning ids are rejected

### DIFF
--- a/umap/tests/test_merge_features.py
+++ b/umap/tests/test_merge_features.py
@@ -1,6 +1,6 @@
 import pytest
 
-from umap.utils import merge_features
+from umap.utils import ConflictError, merge_features
 
 
 def test_adding_one_element():
@@ -50,18 +50,38 @@ def test_removing_same_element():
 
 
 def test_removing_changed_element():
-    with pytest.raises(ValueError):
+    with pytest.raises(ConflictError):
         merge_features(["A", "B"], ["A", "C"], ["A"])
 
 
 def test_changing_removed_element():
-    with pytest.raises(ValueError):
+    with pytest.raises(ConflictError):
         merge_features(["A", "B"], ["A"], ["A", "C"])
 
 
 def test_changing_same_element():
-    with pytest.raises(ValueError):
+    with pytest.raises(ConflictError):
         merge_features(["A", "B"], ["A", "D"], ["A", "C"])
     # Order does not count
-    with pytest.raises(ValueError):
+    with pytest.raises(ConflictError):
         merge_features(["A", "B", "C"], ["B", "D", "A"], ["A", "E", "B"])
+
+
+def test_merge_with_ids_raises():
+    # If reference doesn't have ids, but latest and incoming has
+    # We need to raise as a conflict
+    reference = [
+        {"properties": {}, "geometry": "A"},
+        {"properties": {}, "geometry": "B"},
+    ]
+    latest = [
+        {"properties": {id: "100"}, "geometry": "A"},
+        {"properties": {id: "101"}, "geometry": "B"},
+    ]
+    incoming = [
+        {"properties": {id: "200"}, "geometry": "A"},
+        {"properties": {id: "201"}, "geometry": "B"},
+    ]
+
+    with pytest.raises(ConflictError):
+        merge_features(reference, latest, incoming)


### PR DESCRIPTION
The current code already ensures that items
changed in the reference weren't also changed
in the latest changes, so we are covered.