### PR TITLE
chore: refactor initCenter and controls ordering

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -1234,6 +1234,35 @@ U.StarControl = L.Control.extend({
   },
 })
 
+/*
+ * Take control over L.Control.Locate to be able to
+ * call start() before adding the control (and thus the button) to the map.
+ */
+U.Locate = L.Control.Locate.extend({
+  initialize: function (map, options) {
+    // When calling start(), it will try to add a location marker
+    // on the layer, which is normally added in the addTo/onAdd method
+    this._layer = this.options.layer = new L.LayerGroup()
+    // When calling start(), it will call _activate(), which then adds
+    // location related event listeners on the map
+    this.map = map
+    L.Control.Locate.prototype.initialize.call(this, options)
+  },
+
+  onAdd: function (map) {
+    const active = this._active
+    const container = L.Control.Locate.prototype.onAdd.call(this, map)
+    this._active = active
+    return container
+  },
+
+  _activate: function () {
+    this._map = this.map
+    L.Control.Locate.prototype._activate.call(this)
+    this._map = null
+  }
+})
+
 U.Search = L.PhotonSearch.extend({
   initialize: function (map, input, options) {
     this.options.placeholder = L._('Type a place name or coordinates')

--- a/umap/tests/integration/test_map.py
+++ b/umap/tests/integration/test_map.py
@@ -148,6 +148,18 @@ def test_default_view_latest_with_polygon(map, live_server, page):
     expect(layers).to_have_count(1)
 
 
+def test_default_view_locate(browser, live_server, map):
+    context = browser.new_context(
+        geolocation={"longitude": 8.52967, "latitude": 39.16267},
+        permissions=["geolocation"],
+    )
+    map.settings["properties"]["defaultView"] = "locate"
+    map.save()
+    page = context.new_page()
+    page.goto(f"{live_server.url}{map.get_absolute_url()}")
+    expect(page).to_have_url(re.compile(r".*#18/39\.16267/8\.52967"))
+
+
 def test_remote_layer_should_not_be_used_as_datalayer_for_created_features(
     map, live_server, datalayer, page
 ):


### PR DESCRIPTION
We had an issue (not in Github :p) where a map was not loading because the defaultView was set to "data", and the layers were remote data layers. In this case, when computing the remote URL, we allow to replace georelated variables (like east, west, north, lat…), which needs the map to have a view.
So:
- the default view was expecting the data to be loaded (="data")
- the data to be loaded needed a default view…

So instead of adding yet another call to _setDefaultView in an edge case, we reordered the way we initialize the map elements:

- first we initialize the controls (because initCenter needs the locate control to exist)
- then we call initCenter
- then we initialize the tile layers (because the miniMap needs it to render itself)
- then we call renderControls