### PR TITLE
fix: hide delete button for editors in dashboard

### DIFF
--- a/umap/templates/umap/map_table.html
+++ b/umap/templates/umap/map_table.html
@@ -68,6 +68,7 @@
                   <span class="sr-only">{% translate "Clone" %}</span>
                 </button>
               </form>
+              {% if map_inst|can_delete_map:request %}
               <form action="{% url 'map_delete' map_inst.pk %}"
                     method="post"
                     class="map-delete">
@@ -78,6 +79,7 @@
                   <span class="sr-only">{% translate "Delete" %}</span>
                 </button>
               </form>
+              {% endif %}
             </td>
           </tr>
         {% endwith %}

--- a/umap/templatetags/umap_tags.py
+++ b/umap/templatetags/umap_tags.py
@@ -44,6 +44,11 @@ def tilelayer_preview(tilelayer):
 
 
 @register.filter
+def can_delete_map(map, request):
+    return map.can_delete(request.user, request)
+
+
+@register.filter
 def notag(s):
     return s.replace("<", "&lt;")
 

--- a/umap/tests/integration/test_dashboard.py
+++ b/umap/tests/integration/test_dashboard.py
@@ -36,3 +36,13 @@ def test_dashboard_map_preview(map, live_server, datalayer, login):
     expect(dialog).to_be_visible()
     # Let's check we have a marker on it, so we can guess the map loaded correctly
     expect(dialog.locator(".leaflet-marker-icon")).to_be_visible()
+
+
+def test_no_delete_button_for_editors(map, live_server, datalayer, login, user):
+    map.name = "Map I cannot delete"
+    map.editors.add(user)
+    map.save()
+    page = login(user)
+    page.goto(f"{live_server.url}/en/me")
+    expect(page.get_by_text("Map I cannot delete")).to_be_visible()
+    expect(page.get_by_title("Delete")).to_be_hidden()


### PR DESCRIPTION
fix #1739