### PR TITLE
make that "browse data" opens the browser in expanded mode

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -82,7 +82,6 @@ U.Map = L.Map.extend({
         .split(',')
     }
 
-
     let editedFeature = null
     const self = this
     try {
@@ -207,11 +206,9 @@ U.Map = L.Map.extend({
       if (L.Util.queryString('share')) {
         this.share.open()
       } else if (this.options.onLoadPanel === 'databrowser') {
-        this.panel.mode = 'expanded'
-        this.openBrowser()
+        this.openBrowser('expanded')
       } else if (this.options.onLoadPanel === 'datalayers') {
-        this.panel.mode = 'condensed'
-        this.openBrowser()
+        this.openBrowser('condensed')
       } else if (this.options.onLoadPanel === 'caption') {
         this.panel.mode = 'condensed'
         this.displayCaption()
@@ -334,7 +331,6 @@ U.Map = L.Map.extend({
       if (this.options.editMode === 'advanced') {
         new U.SettingsToolbar({ actions: editActions }).addTo(this)
       }
-
     }
     this._controls.zoom = new L.Control.Zoom({
       zoomInTitle: L._('Zoom in'),
@@ -388,7 +384,7 @@ U.Map = L.Map.extend({
       document.body,
       'umap-caption-bar-enabled',
       this.options.captionBar ||
-      (this.options.slideshow && this.options.slideshow.active)
+        (this.options.slideshow && this.options.slideshow.active)
     )
     L.DomUtil.classIf(
       document.body,
@@ -905,7 +901,8 @@ U.Map = L.Map.extend({
     }
   },
 
-  openBrowser: function () {
+  openBrowser: function (mode) {
+    if (mode) this.panel.mode = mode
     this.onceDatalayersLoaded(function () {
       this.browser.open()
     })
@@ -1582,10 +1579,10 @@ U.Map = L.Map.extend({
 
   initCaptionBar: function () {
     const container = L.DomUtil.create(
-      'div',
-      'umap-caption-bar',
-      this._controlContainer
-    ),
+        'div',
+        'umap-caption-bar',
+        this._controlContainer
+      ),
       name = L.DomUtil.create('h3', '', container)
     L.DomEvent.disableClickPropagation(container)
     this.permissions.addOwnerLink('span', container)
@@ -1601,8 +1598,7 @@ U.Map = L.Map.extend({
         'umap-open-browser-link flat',
         container,
         L._('Browse data'),
-        this.openBrowser,
-        this
+        () => this.openBrowser('expanded')
       )
       if (this.options.facetKey) {
         L.DomUtil.createButton(
@@ -1743,10 +1739,17 @@ U.Map = L.Map.extend({
         })
       }
     }
-    items.push('-', {
-      text: L._('Browse data'),
-      callback: this.openBrowser,
-    })
+    items.push(
+      '-',
+      {
+        text: L._('See layers'),
+        callback: () => this.openBrowser('condensed'),
+      },
+      {
+        text: L._('Browse data'),
+        callback: () => this.openBrowser('expanded'),
+      }
+    )
     if (this.options.facetKey) {
       items.push({
         text: L._('Facet search'),

--- a/umap/tests/integration/test_statics.py
+++ b/umap/tests/integration/test_statics.py
@@ -40,7 +40,7 @@ def test_javascript_have_been_loaded(
     expect(page).to_have_url(re.compile(r".*#7/48\..+/13\..+"))
     expect(page).to_have_url(re.compile(r".*/fr/"))
     # Should be in French, so hashed locale file has been loaded correctly
-    button = page.get_by_text("Voir les calques")
+    button = page.get_by_role("button", name="Voir les calques")
     expect(button).to_be_visible()
     button.click()
     layers = page.locator(".umap-browser .datalayer")


### PR DESCRIPTION
And also add a "See layer" action in the context menu.

I'm not totally sure it's the way to go, but it's closer to the current behaviour, and as a user a way missing a way to go straight to the extanded browser version.