### PR TITLE
fix: make sure we do not render browser in map fragment

### DIFF
--- a/umap/models.py
+++ b/umap/models.py
@@ -213,13 +213,9 @@ class Map(NamedModel):
                 "STATIC_URL": settings.STATIC_URL,
                 "editMode": "disabled",
                 "hash": False,
-                "attributionControl": False,
                 "scrollWheelZoom": False,
-                "umapAttributionControl": False,
                 "noControl": True,
                 "umap_id": self.pk,
-                "onLoadPanel": "none",
-                "captionBar": False,
                 "schema": self.extra_schema,
                 "slideshow": {},
             }

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -197,13 +197,16 @@ U.Map = L.Map.extend({
 
     this.slideshow = new U.Slideshow(this, this.options.slideshow)
     this.permissions = new U.MapPermissions(this)
-    this.initCaptionBar()
     if (this.hasEditMode()) {
       this.editTools = new U.Editable(this)
       this.renderEditToolbar()
     }
     this.initShortcuts()
     this.onceDataLoaded(function () {
+      const slug = L.Util.queryString('feature')
+      if (slug && this.features_index[slug]) this.features_index[slug].view()
+      if (this.options.noControl) return
+      this.initCaptionBar()
       if (L.Util.queryString('share')) {
         this.share.open()
       } else if (this.options.onLoadPanel === 'databrowser') {
@@ -218,8 +221,6 @@ U.Map = L.Map.extend({
       } else if (['facet', 'datafilters'].includes(this.options.onLoadPanel)) {
         this.openFacet()
       }
-      const slug = L.Util.queryString('feature')
-      if (slug && this.features_index[slug]) this.features_index[slug].view()
       if (L.Util.queryString('edit')) {
         if (this.hasEditMode()) this.enableEdit()
         // Sometimes users share the ?edit link by mistake, let's remove

--- a/umap/tests/integration/test_map_list.py
+++ b/umap/tests/integration/test_map_list.py
@@ -1,0 +1,28 @@
+import pytest
+from playwright.sync_api import expect
+
+pytestmark = pytest.mark.django_db
+
+
+def test_should_not_render_any_control(live_server, tilelayer, page, map):
+    map.settings["properties"]["onLoadPanel"] = "databrowser"
+    map.settings["properties"]["miniMap"] = True
+    map.settings["properties"]["captionBar"] = True
+    map.save()
+    # Make sure those controls are visible in normal view
+    page.goto(f"{live_server.url}{map.get_absolute_url()}")
+    expect(page.locator(".leaflet-control-minimap")).to_be_visible()
+    expect(page.locator(".umap-browser")).to_be_visible()
+    expect(page.locator(".umap-caption-bar")).to_be_visible()
+    expect(page.locator(".leaflet-control-zoom")).to_be_visible()
+    expect(page.locator(".leaflet-control-attribution")).to_be_visible()
+
+    # Now load home page to have the list view
+    page.goto(live_server.url)
+    map_el = page.locator(".map_fragment")
+    expect(map_el).to_be_visible()
+    expect(map_el.locator(".leaflet-control-minimap")).to_be_hidden()
+    expect(map_el.locator(".umap-browser")).to_be_hidden()
+    expect(map_el.locator(".umap-caption-bar")).to_be_hidden()
+    expect(map_el.locator(".leaflet-control-zoom")).to_be_hidden()
+    expect(map_el.locator(".leaflet-control-attribution")).to_be_hidden()


### PR DESCRIPTION
There was an edge case when map has "dataLayersControl=expanded": we only overrided "onLoadPanel", so dataLayersControl was still considerer. Let's have a more generic stop.

Before:

![image](https://github.com/umap-project/umap/assets/146023/7e0e7e13-1f75-495d-ace8-1d0b93285b49)


After:

![image](https://github.com/umap-project/umap/assets/146023/60171ec2-fbb8-458c-9ab6-6101911a7af6)
