### PR TITLE
fix: prevent rebuilding the browser at each save

### DIFF
--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -845,8 +845,8 @@ U.DataLayer = L.Evented.extend({
       this.map.datalayers[id] = this
       if (L.Util.indexOf(this.map.datalayers_index, this) === -1)
         this.map.datalayers_index.push(this)
+      this.map.onDataLayersChanged()
     }
-    this.map.onDataLayersChanged()
   },
 
   _dataUrl: function () {


### PR DESCRIPTION
Otherwise we lose the browser current context (some layer may be opened, or user may have scrolled down).

`onDataLayersChanged` will make the browser to be redrawn, and it was called anytime `connectToMap` itself was called, which is at datalayer init and datalayer save, but we can only make this call for a new datalayer.