### PR TITLE
fix: save back map description in DB

### DIFF
--- a/umap/forms.py
+++ b/umap/forms.py
@@ -102,7 +102,7 @@ class MapSettingsForm(forms.ModelForm):
         return self.cleaned_data["center"]
 
     class Meta:
-        fields = ("settings", "name", "center", "slug")
+        fields = ("settings", "name", "description", "center", "slug")
         model = Map
 
 

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -1006,6 +1006,7 @@ U.Map = L.Map.extend({
     }
     const formData = new FormData()
     formData.append('name', this.options.name)
+    formData.append('description', this.options.description)
     formData.append('center', JSON.stringify(this.geometry()))
     formData.append('settings', JSON.stringify(geojson))
     const uri = this.urls.get('map_save', { map_id: this.options.umap_id })


### PR DESCRIPTION
Since a few years, we are not saving description in DB anymore. I'm not sure it's a wanted change.

Other option, given we already have it in the `settings` JSONB column, is to remove the `description` field from the model and make it a `@property` instead that will try to read in the `settings` column