### PR TITLE
fix: do not try to close editPanel if not set

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -524,8 +524,8 @@ U.Map = L.Map.extend({
           this.help.hide()
         } else {
           this.panel.close()
-          this.editPanel.close()
-          this.fullPanel.close()
+          this.editPanel?.close()
+          this.fullPanel?.close()
         }
       }
 


### PR DESCRIPTION
When in the user dashboard and opening a map preview, when we press escape it will try to close non existing panels (they are not instantiated given there is not edit mode there)