### PR TITLE
fix: no .mjs extension for JS modules

### DIFF
--- a/scripts/vendorsjs.sh
+++ b/scripts/vendorsjs.sh
@@ -25,7 +25,7 @@ mkdir -p umap/static/umap/vendors/georsstogeojson/ && cp -r node_modules/georsst
 mkdir -p umap/static/umap/vendors/togpx/ && cp -r node_modules/togpx/togpx.js umap/static/umap/vendors/togpx/
 mkdir -p umap/static/umap/vendors/tokml && cp -r node_modules/tokml/tokml.js umap/static/umap/vendors/tokml
 mkdir -p umap/static/umap/vendors/locatecontrol/ && cp -r node_modules/leaflet.locatecontrol/dist/L.Control.Locate.min.* umap/static/umap/vendors/locatecontrol/
-mkdir -p umap/static/umap/vendors/dompurify/ && cp -r node_modules/dompurify/dist/*.mjs umap/static/umap/vendors/dompurify/
+mkdir -p umap/static/umap/vendors/dompurify/ && cp -r node_modules/dompurify/dist/purify.es.mjs umap/static/umap/vendors/dompurify/purify.es.js
 mkdir -p umap/static/umap/vendors/colorbrewer/ && cp node_modules/colorbrewer/index.js umap/static/umap/vendors/colorbrewer/colorbrewer.js
 mkdir -p umap/static/umap/vendors/simple-statistics/ && cp node_modules/simple-statistics/dist/simple-statistics.min.* umap/static/umap/vendors/simple-statistics/
 mkdir -p umap/static/umap/vendors/iconlayers/ && cp node_modules/leaflet-iconlayers/dist/* umap/static/umap/vendors/iconlayers/

--- a/umap/static/umap/js/modules/dompurify.js
+++ b/umap/static/umap/js/modules/dompurify.js
@@ -1,4 +1,4 @@
-import {default as DOMPurifyInitializer} from '../../vendors/dompurify/purify.es.mjs'
+import { default as DOMPurifyInitializer } from '../../vendors/dompurify/purify.es.js'
 import { JSDOM } from 'jsdom'
 
 console.log(DOMPurifyInitializer)

--- a/umap/static/umap/js/modules/utils.js
+++ b/umap/static/umap/js/modules/utils.js
@@ -1,4 +1,4 @@
-import { default as DOMPurifyInitializer } from '../../vendors/dompurify/purify.es.mjs'
+import { default as DOMPurifyInitializer } from '../../vendors/dompurify/purify.es.js'
 
 /**
  * Generate a pseudo-unique identifier (5 chars long, mixed-case alphanumeric)
@@ -358,7 +358,7 @@ export function template(str, data) {
 }
 
 export function parseNaiveDate(value) {
-    const naive = new Date(value)
-    // Let's pretend naive date are UTC, and remove time…
-    return new Date(Date.UTC(naive.getFullYear(), naive.getMonth(), naive.getDate()))
+  const naive = new Date(value)
+  // Let's pretend naive date are UTC, and remove time…
+  return new Date(Date.UTC(naive.getFullYear(), naive.getMonth(), naive.getDate()))
 }


### PR DESCRIPTION
It requires a special nginx configuration that we want to avoid for all instances deployments:

```
include mime.types;
types {
  application/javascript mjs;
}
```