### PR TITLE
fix: vendorize the .map too for dompurify

### DIFF
--- a/scripts/vendorsjs.sh
+++ b/scripts/vendorsjs.sh
@@ -26,6 +26,7 @@ mkdir -p umap/static/umap/vendors/togpx/ && cp -r node_modules/togpx/togpx.js um
 mkdir -p umap/static/umap/vendors/tokml && cp -r node_modules/tokml/tokml.js umap/static/umap/vendors/tokml
 mkdir -p umap/static/umap/vendors/locatecontrol/ && cp -r node_modules/leaflet.locatecontrol/dist/L.Control.Locate.min.* umap/static/umap/vendors/locatecontrol/
 mkdir -p umap/static/umap/vendors/dompurify/ && cp -r node_modules/dompurify/dist/purify.es.mjs umap/static/umap/vendors/dompurify/purify.es.js
+mkdir -p umap/static/umap/vendors/dompurify/ && cp -r node_modules/dompurify/dist/purify.es.mjs.map umap/static/umap/vendors/dompurify/purify.es.mjs.map
 mkdir -p umap/static/umap/vendors/colorbrewer/ && cp node_modules/colorbrewer/index.js umap/static/umap/vendors/colorbrewer/colorbrewer.js
 mkdir -p umap/static/umap/vendors/simple-statistics/ && cp node_modules/simple-statistics/dist/simple-statistics.min.* umap/static/umap/vendors/simple-statistics/
 mkdir -p umap/static/umap/vendors/iconlayers/ && cp node_modules/leaflet-iconlayers/dist/* umap/static/umap/vendors/iconlayers/


### PR DESCRIPTION
Fix up for  2c1cd46167402d7dca4e4ffb4689ec93ee01e5e8

We keep the `.mjs` fragment within the filename to avoid changing it manually within the renamed `purify.es.js` file. Given the `.map` extension, it will not affect the nginx (or others) mimetypes configuration.