### PR TITLE
Add max-width to panel in landscape mode

### DIFF
--- a/umap/static/umap/css/panel.css
+++ b/umap/static/umap/css/panel.css
@@ -90,6 +90,7 @@
         top: 0;
         margin-top: var(--panel-gutter);
         width: var(--panel-width);
+        max-width: calc(100% - var(--panel-gutter) * 2 - var(--control-size))
     }
     .panel.condensed {
         max-height: 500px;


### PR DESCRIPTION
In some situation in mobile (eg. when the keyboard is used), the screen is still considered as landscape, but it is very small, so make sure the panel does not overflow on the right.

cf #1788