### PR TITLE
Expanded docker.md documentation

### DIFF
--- a/docs/config/icons.md
+++ b/docs/config/icons.md
@@ -22,7 +22,7 @@ You can import icons manually by going to your uMap admin page: `https://your.se
 
 ## Import icons automatically
 
-To import icons on your uMap server, you will need to use the command `umap import_pictograms` from inside main project folder.
+To import icons on your uMap server, you will need to use the command `umap import_pictograms` (making sure the virtualenv is active).
 
 Note: you can get help with `umap import_pictograms -h`
 

--- a/docs/config/icons.md
+++ b/docs/config/icons.md
@@ -22,7 +22,7 @@ You can import icons manually by going to your uMap admin page: `https://your.se
 
 ## Import icons automatically
 
-To import icons on your uMap server, you will need to use the command `umap import_pictograms`.
+To import icons on your uMap server, you will need to use the command `umap import_pictograms` from inside main project folder.
 
 Note: you can get help with `umap import_pictograms -h`
 

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -27,7 +27,8 @@ services:
     volumes:
       - umap_userdata:/srv/umap/uploads
       # FIX the path on the left, below, to your location 
-      # OPTIONAL, you can comment the line below out
+      # OPTIONAL, you can comment the line below out for default
+      # values to apply
       - /home/ubuntu/umap.conf:/etc/umap/umap.conf
     restart: always
     depends_on:
@@ -44,4 +45,7 @@ Note that you’ll have to set a [`SECRET_KEY`](https://docs.djangoproject.com/e
 $ python3 -c 'import secrets; print(secrets.token_hex(100))'
 ```
 
-User accounts can be managed via the Django admin page ({SITE_URL}/admin). The required superuser must be created on the container command line with this command: umap createsuperuser.
+User accounts can be managed via the Django admin page ({SITE_URL}/admin). The required superuser must be created on the container command line with this command:
+```bash
+umap createsuperuser
+```

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -27,6 +27,7 @@ services:
     volumes:
       - umap_userdata:/srv/umap/uploads
       # FIX the path on the left, below, to your location 
+      # OPTIONAL, you can comment the line below out
       - /home/ubuntu/umap.conf:/etc/umap/umap.conf
     restart: always
     depends_on:
@@ -42,3 +43,5 @@ Note that you’ll have to set a [`SECRET_KEY`](https://docs.djangoproject.com/e
 ```sh
 $ python3 -c 'import secrets; print(secrets.token_hex(100))'
 ```
+
+User accounts can be managed via the Django admin page ({SITE_URL}/admin). The required superuser must be created on the container command line with this command: umap createsuperuser.


### PR DESCRIPTION
Hi,
after having initial issues with `umap.conf` not being found while using docker container i think it could be helpful to add a few more lines in the `docker.md` for a better start off.
- Added a comment below the `umap.conf` path definition asserting it is an optional setting
- Specified how to create an admin user and how to access it, otherwise you will experience problems in saving maps or adding tile-layers 