### PR TITLE
fix: adapt panel expanded height when map has a caption bar

### DIFF
--- a/umap/static/umap/css/panel.css
+++ b/umap/static/umap/css/panel.css
@@ -139,4 +139,8 @@
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
     }
+    .umap-caption-bar-enabled .panel.expanded {
+        height: calc(100% - var(--footer-height));
+        max-height: calc(100% - var(--footer-height));
+    }
 }


### PR DESCRIPTION
cf #1788

Before:

![image](https://github.com/umap-project/umap/assets/146023/277522ec-87a3-4f42-af2c-03e6edeee427)

After:

![image](https://github.com/umap-project/umap/assets/146023/89a035e8-cfb6-4442-9732-8e65d4a345e0)
