### PR TITLE
feat: use accent color for switch and multichoices on dark background

### DIFF
--- a/umap/static/umap/base.css
+++ b/umap/static/umap/base.css
@@ -449,9 +449,10 @@ input.switch:checked ~ label:before {
     text-indent: 0.7em;
     text-align: left;
     font-weight: bold;
+}
 .dark input.switch:checked ~ label:before {
     border: none;
-}
+    background-color: var(--color-accent);
 }
 input.switch:checked ~ label:after {
     margin-left: 3em;
@@ -497,7 +498,7 @@ input.switch:checked ~ label:after {
     background-color: #2c3233;
 }
 .umap-multiplechoice input[type='radio']:checked + label {
-    background-color: var(--color-lightCyan);
+    background-color: var(--color-accent);
     box-shadow: inset 0 0 6px 0px #2c3233;
     color: var(--color-darkGray);
 }


### PR DESCRIPTION
Before:
![image](https://github.com/umap-project/umap/assets/146023/5e42942a-34c5-4cb0-a801-97c5838e4a43)

After:
![image](https://github.com/umap-project/umap/assets/146023/019e1d50-c727-49e4-8111-c0d49fc8899c)

cc @Aurelie-Jallut cf discussion on Mattermost, but so you can have an other look at it