### PR TITLE
fix: do not close blindly editPanel when deleting a layer

### DIFF
--- a/umap/static/umap/js/modules/caption.js
+++ b/umap/static/umap/js/modules/caption.js
@@ -7,6 +7,15 @@ export default class Caption {
     this.map = map
   }
 
+  isOpen() {
+    return Boolean(document.querySelector('.on .umap-caption'))
+  }
+
+  refresh() {
+    if (!this.isOpen()) return
+    this.open()
+  }
+
   open() {
     const container = DomUtil.create('div', 'umap-caption')
     DomUtil.createTitle(container, this.map.options.name, 'icon-caption')

--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -607,7 +607,6 @@ U.DataLayer.include({
           if (!this.isVisible()) return
           if (!confirm(L._('Are you sure you want to delete this layer?'))) return
           this._delete()
-          this.map.editPanel.close()
         },
         this
       )
@@ -624,6 +623,13 @@ U.DataLayer.include({
 
   getHidableClass: function () {
     return `show_with_datalayer_${L.stamp(this)}`
+  },
+
+  propagateDelete: function () {
+    const els = this.getHidableElements()
+    for (const el of els) {
+      L.DomUtil.remove(el)
+    }
   },
 
   propagateRemote: function () {
@@ -653,6 +659,7 @@ U.DataLayer.include({
 U.DataLayer.addInitHook(function () {
   this.on('hide', this.propagateHide)
   this.on('show', this.propagateShow)
+  this.on('erase', this.propagateDelete)
   if (this.isVisible()) this.propagateShow()
 })
 

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -475,6 +475,7 @@ U.Map = L.Map.extend({
 
   onDataLayersChanged: function () {
     if (this.browser) this.browser.update()
+    this.caption.refresh()
   },
 
   ensurePanesOrder: function () {

--- a/umap/tests/integration/test_edit_datalayer.py
+++ b/umap/tests/integration/test_edit_datalayer.py
@@ -183,3 +183,32 @@ def test_can_edit_layer_on_ctrl_shift_click(live_server, openmap, page, datalaye
     page.goto(f"{live_server.url}{openmap.get_absolute_url()}?edit")
     page.locator(".leaflet-marker-icon").click(modifiers=[modifier, "Shift"])
     expect(page.get_by_text("Layer properties")).to_be_visible()
+
+
+def test_deleting_datalayer_should_remove_from_browser_and_layers_list(
+    live_server, openmap, datalayer, page
+):
+    page.goto(f"{live_server.url}{openmap.get_absolute_url()}?edit")
+    panel = page.locator(".panel.left")
+    edit_panel = page.locator(".panel.right")
+    page.get_by_title("See layers").click()
+    page.get_by_role("link", name="Manage layers").click()
+    expect(panel.get_by_text("test datalayer")).to_be_visible()
+    expect(edit_panel.get_by_text("test datalayer")).to_be_visible()
+    page.once("dialog", lambda dialog: dialog.accept())
+    page.locator(".panel.right").get_by_title("Delete layer").click()
+    expect(panel.get_by_text("test datalayer")).to_be_hidden()
+    expect(edit_panel.get_by_text("test datalayer")).to_be_hidden()
+
+
+def test_deleting_datalayer_should_remove_from_caption(
+    live_server, openmap, datalayer, page
+):
+    page.goto(f"{live_server.url}{openmap.get_absolute_url()}?edit")
+    panel = page.locator(".panel.left")
+    page.get_by_role("button", name="About").click()
+    page.get_by_role("link", name="Manage layers").click()
+    expect(panel.get_by_text("test datalayer")).to_be_visible()
+    page.once("dialog", lambda dialog: dialog.accept())
+    page.locator(".panel.right").get_by_title("Delete layer").click()
+    expect(panel.get_by_text("test datalayer")).to_be_hidden()


### PR DESCRIPTION
But remove from layers list, and make sure browser and caption are up to date.

fix #498
fix #1831