### PR TITLE
fix: support old storage options when importing a umap file

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -877,7 +877,11 @@ U.Map = L.Map.extend({
     if (importedData.geometry) this.options.center = this.latLng(importedData.geometry)
     const self = this
     importedData.layers.forEach((geojson) => {
-      delete geojson._umap_options['id'] // Never trust an id at this stage
+      if (!geojson._umap_options && geojson._storage) {
+        geojson._umap_options = geojson._storage
+        delete geojson._storage
+      }
+      delete geojson._umap_options?.id // Never trust an id at this stage
       const dataLayer = self.createDataLayer(geojson._umap_options)
       dataLayer.fromUmapGeoJSON(geojson)
     })


### PR DESCRIPTION
From a bug report on Matrix.