### PR TITLE
refactoring(sync): Simplify the design of the sync engine.

### DIFF
--- a/umap/static/umap/js/modules/sync/updaters.js
+++ b/umap/static/umap/js/modules/sync/updaters.js
@@ -15,7 +15,7 @@ class BaseUpdater {
     // Reduce the current list of attributes,
     // to find the object to set the property onto
     const objectToSet = parts.reduce((currentObj, part) => {
-      if (part in currentObj) return currentObj[part]
+      if (currentObj !== undefined && part in currentObj) return currentObj[part]
     }, obj)
 
     // In case the given path doesn't exist, stop here

--- a/umap/static/umap/js/modules/sync/websocket.js
+++ b/umap/static/umap/js/modules/sync/websocket.js
@@ -9,7 +9,7 @@ export class WebSocketTransport {
   }
 
   onMessage(wsMessage) {
-    this.receiver.dispatch(JSON.parse(wsMessage.data))
+    this.receiver.receive(JSON.parse(wsMessage.data))
   }
 
   send(kind, payload) {

--- a/umap/static/umap/unittests/sync.js
+++ b/umap/static/umap/unittests/sync.js
@@ -5,7 +5,7 @@ import pkg from 'chai'
 const { expect } = pkg
 
 import { MapUpdater } from '../js/modules/sync/updaters.js'
-import { MessagesDispatcher, SyncEngine } from '../js/modules/sync/engine.js'
+import { SyncEngine } from '../js/modules/sync/engine.js'
 
 describe('SyncEngine', () => {
   it('should initialize methods even before start', function () {
@@ -16,35 +16,33 @@ describe('SyncEngine', () => {
   })
 })
 
-describe('MessageDispatcher', () => {
-  describe('#dispatch', function () {
-    it('should raise an error on unknown updater', function () {
-      const dispatcher = new MessagesDispatcher({})
-      expect(() => {
-        dispatcher.dispatch({
-          kind: 'operation',
-          subject: 'unknown',
-          metadata: {},
-        })
-      }).to.throw(Error)
-    })
-    it('should produce an error on malformated messages', function () {
-      const dispatcher = new MessagesDispatcher({})
-      expect(() => {
-        dispatcher.dispatch({
-          yeah: 'yeah',
-          payload: { foo: 'bar' },
-        })
-      }).to.throw(Error)
-    })
-    it('should raise an unknown operations', function () {
-      const dispatcher = new MessagesDispatcher({})
-      expect(() => {
-        dispatcher.dispatch({
-          kind: 'something-else',
-        })
-      }).to.throw(Error)
-    })
+describe('#dispatch', function () {
+  it('should raise an error on unknown updater', function () {
+    const dispatcher = new SyncEngine({})
+    expect(() => {
+      dispatcher.dispatch({
+        kind: 'operation',
+        subject: 'unknown',
+        metadata: {},
+      })
+    }).to.throw(Error)
+  })
+  it('should produce an error on malformated messages', function () {
+    const dispatcher = new SyncEngine({})
+    expect(() => {
+      dispatcher.dispatch({
+        yeah: 'yeah',
+        payload: { foo: 'bar' },
+      })
+    }).to.throw(Error)
+  })
+  it('should raise an unknown operations', function () {
+    const dispatcher = new SyncEngine({})
+    expect(() => {
+      dispatcher.dispatch({
+        kind: 'something-else',
+      })
+    }).to.throw(Error)
   })
 })
 


### PR DESCRIPTION
Removes the concept of message dispatcher and message sender, all of it can be done by the syncengine class, making it easier to grasp.