### PR TITLE
fix: use correct icon class in edit feature panel

### DIFF
--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -144,7 +144,7 @@ U.FeatureMixin = {
   edit: function (e) {
     if (!this.map.editEnabled || this.isReadOnly()) return
     const container = L.DomUtil.create('div', 'umap-feature-container')
-    L.DomUtil.createTitle(container, L._('Feature properties'), this.getClassName())
+    L.DomUtil.createTitle(container, L._('Feature properties'), `icon-${this.getClassName()}`)
 
     let builder = new U.FormBuilder(
       this,


### PR DESCRIPTION
Before:

![image](https://github.com/umap-project/umap/assets/146023/042ff918-5d7e-4114-81b0-224989478c1f)


After:

![image](https://github.com/umap-project/umap/assets/146023/f960ebeb-4171-401d-9ac1-9102e7749fc3)
