### PR TITLE
fix: display an alert on any request error

### DIFF
--- a/umap/static/umap/js/modules/request.js
+++ b/umap/static/umap/js/modules/request.js
@@ -144,6 +144,8 @@ export class ServerRequest extends Request {
   _onNOK(error) {
     if (error.status === 403) {
       Alert.error(error.message || translate('Action not allowed :('))
+    } else {
+      super._onError(error)
     }
     return [{}, error.response, error]
   }

--- a/umap/templates/umap/content.html
+++ b/umap/templates/umap/content.html
@@ -12,7 +12,9 @@
   <header class="wrapper row">
     {% include "umap/navigation.html" with title=SITE_NAME %}
   </header>
-  {% include "umap/messages.html" with title=SITE_NAME %}
+  {% block messages %}
+    {% include "umap/messages.html" with title=SITE_NAME %}
+  {% endblock messages %}
 {% endblock header %}
 {% block content %}
   {% if UMAP_READONLY %}

--- a/umap/templates/umap/home.html
+++ b/umap/templates/umap/home.html
@@ -1,5 +1,8 @@
 {% extends "umap/content.html" %}
 {% load umap_tags i18n %}
+{% block messages %}
+  {# We don't want maps in the list to display errors. #}
+{% endblock messages %}
 {% block maincontent %}
   {% include "umap/search_bar.html" %}
   {% include "umap/about_summary.html" %}

--- a/umap/templates/umap/search.html
+++ b/umap/templates/umap/search.html
@@ -1,5 +1,8 @@
 {% extends "umap/content.html" %}
 {% load i18n %}
+{% block messages %}
+  {# We don't want maps from the results list to display errors in the main page. #}
+{% endblock messages %}
 {% block maincontent %}
   {% include "umap/search_bar.html" %}
   <div class="wrapper">


### PR DESCRIPTION
This used to be the case, but was changed by mistake in the request refactor (switch from xhr)