### PR TITLE
fix: use layer labelKey if any when filtering features

### DIFF
--- a/umap/static/umap/js/modules/browser.js
+++ b/umap/static/umap/js/modules/browser.js
@@ -143,8 +143,6 @@ export default class Browser {
   open(mode) {
     // Force only if mode is known, otherwise keep current mode.
     if (mode) this.mode = mode
-    // Get once but use it for each feature later
-    this.filterKeys = this.map.getFilterKeys()
     const container = DomUtil.create('div')
     // HOTFIX. Remove when this is released:
     // https://github.com/Leaflet/Leaflet/pull/9052

--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -144,7 +144,11 @@ U.FeatureMixin = {
   edit: function (e) {
     if (!this.map.editEnabled || this.isReadOnly()) return
     const container = L.DomUtil.create('div', 'umap-feature-container')
-    L.DomUtil.createTitle(container, L._('Feature properties'), `icon-${this.getClassName()}`)
+    L.DomUtil.createTitle(
+      container,
+      L._('Feature properties'),
+      `icon-${this.getClassName()}`
+    )
 
     let builder = new U.FormBuilder(
       this,
@@ -528,7 +532,7 @@ U.FeatureMixin = {
   },
 
   isFiltered: function () {
-    const filterKeys = this.map.getFilterKeys()
+    const filterKeys = this.datalayer.getFilterKeys()
     const filter = this.map.browser.options.filter
     if (filter && !this.matchFilter(filter, filterKeys)) return true
     if (!this.matchFacets()) return true
@@ -537,6 +541,10 @@ U.FeatureMixin = {
 
   matchFilter: function (filter, keys) {
     filter = filter.toLowerCase()
+    if (U.Utils.hasVar(keys)) {
+      return this.getDisplayName().toLowerCase().indexOf(filter) !== -1
+    }
+    keys = keys.split(',')
     for (let i = 0, value; i < keys.length; i++) {
       value = (this.properties[keys[i]] || '') + ''
       if (value.toLowerCase().indexOf(filter) !== -1) return true
@@ -598,7 +606,7 @@ U.FeatureMixin = {
     if (locale) properties.locale = locale
     if (L.lang) properties.lang = L.lang
     properties.rank = this.getRank() + 1
-    if (this.hasGeom()) {
+    if (this._map && this.hasGeom()) {
       center = this.getCenter()
       properties.lat = center.lat
       properties.lon = center.lng

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -1873,10 +1873,6 @@ U.Map = L.Map.extend({
     if (this._controls.search) this._controls.search.open()
   },
 
-  getFilterKeys: function () {
-    return (this.options.filterKey || this.options.sortKey || 'name').split(',')
-  },
-
   getLayersBounds: function () {
     const bounds = new L.latLngBounds()
     this.eachBrowsableDataLayer((d) => {

--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -1757,6 +1757,16 @@ U.DataLayer = L.Evented.extend({
     const editor = new U.TableEditor(this)
     editor.edit()
   },
+
+  getFilterKeys: function () {
+    // This keys will be used to filter feature from the browser text input.
+    // By default, it will we use the "name" property, which is also the one used as label in the features list.
+    // When map owner has configured another label or sort key, we try to be smart and search in the same keys.
+    if (this.map.options.filterKey) return this.map.options.filterKey
+    else if (this.options.labelKey) return this.options.labelKey
+    else if (this.map.options.sortKey) return this.map.options.sortKey
+    else return 'name'
+  },
 })
 
 L.TileLayer.include({


### PR DESCRIPTION
fix #1908

At some point, we may want to cache the computation of `feature.getDisplayName()`, and maybe `layer.getFilterKeys()`, in case there are hundreds of features it may impact the UI.