### PR TITLE
fix: also use white-space: pre-line on map description

### DIFF
--- a/umap/static/umap/base.css
+++ b/umap/static/umap/base.css
@@ -778,6 +778,11 @@ input[type=hidden].blur + [type="button"] {
 /*   Various   */
 /* *********** */
 
+.text {
+    word-break: break-word;
+    white-space: pre-line;
+}
+
 .umap-dragover:before {
     content:  ' ';
     background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="arcs">%3Cpath d="M3 15v4c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2v-4M17 9l-5 5-5-5M12 12.8V2.5"/>%3C/svg>');

--- a/umap/static/umap/js/modules/caption.js
+++ b/umap/static/umap/js/modules/caption.js
@@ -24,7 +24,7 @@ export default class Caption {
     if (this.map.options.description) {
       const description = DomUtil.element({
         tagName: 'div',
-        className: 'umap-map-description',
+        className: 'umap-map-description text',
         safeHTML: Utils.toHTML(this.map.options.description),
         parent: container,
       })

--- a/umap/static/umap/js/umap.popup.js
+++ b/umap/static/umap/js/umap.popup.js
@@ -107,7 +107,7 @@ U.PopupTemplate.Default = L.Class.extend({
   renderBody: function () {
     const template = this.feature.getOption('popupContentTemplate')
     const target = this.feature.getOption('outlinkTarget')
-    const container = L.DomUtil.create('div', 'umap-popup-container')
+    const container = L.DomUtil.create('div', 'umap-popup-container text')
     let content = ''
     let properties
     let center

--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -1559,8 +1559,6 @@ span.popup-icon {
 }
 .umap-popup-container {
     flex-grow: 1;
-    word-break: break-word;
-    white-space: pre-line;
     margin-bottom: 10px;
 }
 .umap-popup-container ul {


### PR DESCRIPTION
We removed line breaks management on the JS side so to manage it in CSS, but this CSS was only active on popup/panels for features. Let's have a class for this, and add it to the map description to (about panel).