### PR TITLE
Multiple sync-related fixes

### DIFF
--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -23,7 +23,7 @@ U.FeatureMixin = {
     // event triggered to cause a sync event, as it would reintroduce
     // deleted features.
     // The `._marked_for_deletion` private property is here to track this status.
-    if (this._marked_for_deletion == true) {
+    if (this._marked_for_deletion === true) {
       this._marked_for_deletion = false
       return
     }
@@ -37,7 +37,7 @@ U.FeatureMixin = {
   initialize: function (map, latlng, options, id) {
     this.map = map
     this.sync = map.sync_engine.proxy(this)
-    this._mark_for_deletion = false
+    this._marked_for_deletion = false
 
     if (typeof options === 'undefined') {
       options = {}

--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -6,7 +6,7 @@ U.FeatureMixin = {
       subject: 'feature',
       metadata: {
         id: this.id,
-        layerId: this.datalayer?.id || null,
+        layerId: this.datalayer?.umap_id || null,
         featureType: this.getClassName(),
       },
     }

--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -15,7 +15,18 @@ U.FeatureMixin = {
   onCommit: function () {
     // When the layer is a remote layer, we don't want to sync the creation of the
     // points via the websocket, as the other peers will get them themselves.
-    if (this.datalayer.isRemoteLayer()) return
+    if (this.datalayer?.isRemoteLayer()) return
+
+    // The "endEdit" event is triggered at the end of an edition,
+    // and will trigger the sync.
+    // In the case of a deletion (or a change of layer), we don't want this
+    // event triggered to cause a sync event, as it would reintroduce
+    // deleted features.
+    // The `._marked_for_deletion` private property is here to track this status.
+    if (this._marked_for_deletion == true) {
+      this._marked_for_deletion = false
+      return
+    }
     this.sync.upsert(this.toGeoJSON())
   },
 
@@ -23,13 +34,10 @@ U.FeatureMixin = {
     return this.toGeoJSON().geometry
   },
 
-  syncDelete: function () {
-    this.sync.delete()
-  },
-
   initialize: function (map, latlng, options, id) {
     this.map = map
     this.sync = map.sync_engine.proxy(this)
+    this._mark_for_deletion = false
 
     if (typeof options === 'undefined') {
       options = {}
@@ -276,14 +284,12 @@ U.FeatureMixin = {
     }
     return false
   },
+
   del: function (sync) {
     this.isDirty = true
     this.map.closePopup()
     if (this.datalayer) {
-      this.datalayer.removeLayer(this)
-      this.disconnectFromDataLayer(this.datalayer)
-
-      if (sync !== false) this.syncDelete()
+      this.datalayer.removeLayer(this, sync)
     }
   },
 
@@ -326,7 +332,9 @@ U.FeatureMixin = {
       this.datalayer.isDirty = true
       this.datalayer.removeLayer(this)
     }
+
     datalayer.addLayer(this)
+    this.sync.upsert(this.toGeoJSON())
     datalayer.isDirty = true
     this._redraw()
   },
@@ -508,6 +516,7 @@ U.FeatureMixin = {
   onRemove: function (map) {
     this.parentClass.prototype.onRemove.call(this, map)
     if (this.map.editedFeature === this) {
+      this._marked_for_deletion = true
       this.endEdit()
       this.map.editPanel.close()
     }

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -470,7 +470,8 @@ U.Map = L.Map.extend({
   initDataLayers: async function (datalayers) {
     datalayers = datalayers || this.options.datalayers
     for (const options of datalayers) {
-      this.createDataLayer(options)
+      // `false` to not propagate syncing elements served from uMap
+      this.createDataLayer(options, false)
     }
     await this.loadDataLayers()
   },

--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -745,8 +745,8 @@ U.DataLayer = L.Evented.extend({
     }
   },
 
-  fromGeoJSON: function (geojson) {
-    this.addData(geojson)
+  fromGeoJSON: function (geojson, sync = true) {
+    this.addData(geojson, sync)
     this._geojson = geojson
     this._dataloaded = true
     this.fire('dataloaded')
@@ -757,7 +757,7 @@ U.DataLayer = L.Evented.extend({
     if (geojson._storage) geojson._umap_options = geojson._storage // Retrocompat
     if (geojson._umap_options) this.setOptions(geojson._umap_options)
     if (this.isRemoteLayer()) await this.fetchRemoteData()
-    else this.fromGeoJSON(geojson)
+    else this.fromGeoJSON(geojson, false)
     this._loaded = true
   },
 
@@ -939,11 +939,11 @@ U.DataLayer = L.Evented.extend({
     if (idx !== -1) this._propertiesIndex.splice(idx, 1)
   },
 
-  addData: function (geojson) {
+  addData: function (geojson, sync) {
     try {
       // Do not fail if remote data is somehow invalid,
       // otherwise the layer becomes uneditable.
-      this.geojsonToFeatures(geojson)
+      this.geojsonToFeatures(geojson, sync)
     } catch (err) {
       console.log('Error with DataLayer', this.umap_id)
       console.error(err)
@@ -1030,7 +1030,7 @@ U.DataLayer = L.Evented.extend({
   // The choice of the name is not ours, because it is required by Leaflet.
   // It is misleading, as the returned objects are uMap objects, and not
   // GeoJSON features.
-  geojsonToFeatures: function (geojson) {
+  geojsonToFeatures: function (geojson, sync) {
     if (!geojson) return
     const features = geojson instanceof Array ? geojson : geojson.features
     let i
@@ -1049,7 +1049,7 @@ U.DataLayer = L.Evented.extend({
     let feature = this.geoJSONToLeaflet({ geometry, geojson })
     if (feature) {
       this.addLayer(feature)
-      feature.onCommit()
+      if (sync) feature.onCommit()
       return feature
     }
   },

--- a/umap/static/umap/js/umap.layer.js
+++ b/umap/static/umap/js/umap.layer.js
@@ -911,8 +911,9 @@ U.DataLayer = L.Evented.extend({
     if (this.hasDataLoaded()) this.fire('datachanged')
   },
 
-  removeLayer: function (feature) {
+  removeLayer: function (feature, sync) {
     const id = L.stamp(feature)
+    if (sync !== false) feature.sync.delete()
     this.layer.removeLayer(feature)
     feature.disconnectFromDataLayer(this)
     this._index.splice(this._index.indexOf(id), 1)


### PR DESCRIPTION
I found some issues with the current implementation of the sync mechanism, which this PR fixes.

- The "move a feature from one datalayer to another" feature was not thought of, at all, and as a result introduced the bug that was referenced in #1931.
- It turns out that the syncing of this operation wasn't working either, creating shape clones along the way.
- The previous (buggy) implementation was not sending the proper layer id, resulting to features hosted by the wrong layers.
- Operations were triggered when loading data from the original server, which shouldn't happen.

Generally speaking, the current implementation misses some cross-datalayer tests, but I suggest these should come as a separate pull request.