### PR TITLE
fix: BlurInput was not updating the object in some situations

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "leaflet-contextmenu": "^1.4.0",
     "leaflet-editable": "^1.2.0",
     "leaflet-editinosm": "0.2.3",
-    "leaflet-formbuilder": "0.2.9",
+    "leaflet-formbuilder": "0.2.10",
     "leaflet-fullscreen": "1.0.2",
     "leaflet-hash": "0.2.1",
     "leaflet-i18n": "0.3.5",

--- a/umap/static/umap/js/umap.features.js
+++ b/umap/static/umap/js/umap.features.js
@@ -755,8 +755,8 @@ U.Marker = L.Marker.extend({
       callback: function () {
         if (!this._latlng.isValid()) {
           U.Alert.error(L._('Invalid latitude or longitude'))
-          builder.resetField('_latlng.lat')
-          builder.resetField('_latlng.lng')
+          builder.restoreField('_latlng.lat')
+          builder.restoreField('_latlng.lng')
         }
         this.zoomTo({ easing: false })
       },

--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -456,6 +456,7 @@ L.FormBuilder.BlurInput.include({
     L.FormBuilder.Input.prototype.build.call(this)
     const button = L.DomUtil.create('span', 'button blur-button')
     L.DomUtil.after(this.input, button)
+    L.DomEvent.on(this.input, 'focus', this.fetch, this)
   },
 })
 
@@ -903,8 +904,8 @@ L.FormBuilder.MultiChoice = L.FormBuilder.Element.extend({
   },
 
   fetch: function () {
-    this.backup = this.toHTML()
-    let value = this.backup
+    this.initial = this.toHTML()
+    let value = this.initial
     if (!this.container.querySelector(`input[type="radio"][value="${value}"]`)) {
       value = this.options.default !== undefined ? this.options.default : this.default
     }


### PR DESCRIPTION
Steps to reproduce:
- click in any BlurInput
- change to any value
- click outside the input => the value will be set to the object
- click again in the input
- change value to the initial
- click outside => the value will not be set

This is because the BlurInput in sync on blur, and it was comparing the current field value with an "initial" one, only set at build. This check is made because we don't want to trigger an edit when a user click in a blurinput and click outside without changing the value.