### PR TITLE
fix: broken sortKey help

### DIFF
--- a/umap/static/umap/js/modules/schema.js
+++ b/umap/static/umap/js/modules/schema.js
@@ -112,6 +112,7 @@ export const SCHEMA = {
     type: Boolean,
     impacts: [],
     default: false,
+    label: translate('Animated transitions'),
   },
   editinosmControl: {
     type: Boolean,
@@ -130,6 +131,9 @@ export const SCHEMA = {
   facetKey: {
     type: String,
     impacts: ['ui'],
+    helpEntries: ['facetKey'],
+    placeholder: translate('Example: key1,key2|Label 2,key3|Label 3|checkbox'),
+    label: translate('Filters keys'),
   },
   fill: {
     type: Boolean,
@@ -160,6 +164,10 @@ export const SCHEMA = {
   filterKey: {
     type: String,
     impacts: [],
+    helpEntries: ['filterKey'],
+    placeholder: translate('Default: name'),
+    label: translate('Search keys'),
+    inheritable: true,
   },
   fromZoom: {
     type: Number,
@@ -437,6 +445,9 @@ export const SCHEMA = {
   slugKey: {
     type: String,
     impacts: [],
+    helpEntries: ['slugKey'],
+    placeholder: translate('Default: name'),
+    label: translate('Feature identifier key'),
   },
   smoothFactor: {
     type: Number,
@@ -452,6 +463,10 @@ export const SCHEMA = {
   sortKey: {
     type: String,
     impacts: ['datalayer-index', 'data'],
+    helpEntries: ['sortKey'],
+    placeholder: translate('Default: name'),
+    label: translate('Sort key'),
+    inheritable: true,
   },
   starControl: {
     type: Boolean,

--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -220,9 +220,9 @@ L.FormBuilder.Element.include({
     if (this.options.label) {
       this.label = L.DomUtil.create('label', '', this.getLabelParent())
       this.label.textContent = this.label.title = this.options.label
-      if (this.options.helpEntries)
+      if (this.options.helpEntries) {
         this.builder.map.help.button(this.label, this.options.helpEntries)
-      else if (this.options.helpTooltip) {
+      } else if (this.options.helpTooltip) {
         const info = L.DomUtil.create('i', 'info', this.label)
         L.DomEvent.on(
           info,
@@ -1098,6 +1098,13 @@ U.FormBuilder = L.FormBuilder.extend({
     className: 'umap-form',
   },
 
+  customHandlers: {
+    sortKey: 'BlurInput',
+    easing: 'Switch',
+    facetKey: 'BlurInput',
+    slugKey: 'BlurInput',
+  },
+
   computeDefaultOptions: function () {
     for (const [key, schema] of Object.entries(U.SCHEMA)) {
       if (schema.type === Boolean) {
@@ -1134,6 +1141,9 @@ U.FormBuilder = L.FormBuilder.extend({
             schema.handler = 'LicenceChooser'
             break
         }
+      }
+      if (this.customHandlers[key]) {
+        schema.handler = this.customHandlers[key]
       }
       // FormBuilder use this key for the input type itself
       delete schema.type

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -1219,46 +1219,12 @@ U.Map = L.Map.extend({
   _editDefaultProperties: function (container) {
     const optionsFields = [
       'options.zoomTo',
-      ['options.easing', { handler: 'Switch', label: L._('Animated transitions') }],
+      'options.easing',
       'options.labelKey',
-      [
-        'options.sortKey',
-        {
-          handler: 'BlurInput',
-          helpEntries: 'sortKey',
-          placeholder: L._('Default: name'),
-          label: L._('Sort key'),
-          inheritable: true,
-        },
-      ],
-      [
-        'options.filterKey',
-        {
-          handler: 'Input',
-          helpEntries: 'filterKey',
-          placeholder: L._('Default: name'),
-          label: L._('Search keys'),
-          inheritable: true,
-        },
-      ],
-      [
-        'options.facetKey',
-        {
-          handler: 'BlurInput',
-          helpEntries: 'facetKey',
-          placeholder: L._('Example: key1,key2|Label 2,key3|Label 3|checkbox'),
-          label: L._('Filters keys'),
-        },
-      ],
-      [
-        'options.slugKey',
-        {
-          handler: 'BlurInput',
-          helpEntries: 'slugKey',
-          placeholder: L._('Default: name'),
-          label: L._('Feature identifier key'),
-        },
-      ],
+      'options.sortKey',
+      'options.filterKey',
+      'options.facetKey',
+      'options.slugKey',
     ]
 
     builder = new U.FormBuilder(this, optionsFields)


### PR DESCRIPTION
And move properties to shema.js. Given those keys does not have a "guessable" handler, let's have a "customHandlers" prop to deal with those (instead of keeping them outside of the schema…)

fix #2006