### PR TITLE
fix: catch login_required from map page and add a way to login

### DIFF
--- a/umap/settings/base.py
+++ b/umap/settings/base.py
@@ -152,7 +152,7 @@ WSGI_APPLICATION = "umap.wsgi.application"
 
 LOGIN_URL = "/login/"
 LOGOUT_URL = "/logout/"
-LOGIN_REDIRECT_URL = "/"
+LOGIN_REDIRECT_URL = "login_popup_end"
 
 STATIC_URL = "/static/"
 MEDIA_URL = "/uploads/"

--- a/umap/static/umap/js/modules/permissions.js
+++ b/umap/static/umap/js/modules/permissions.js
@@ -34,7 +34,7 @@ export class MapPermissions {
   }
 
   isOwner() {
-    return this.map.options.user?.id === this.map.options.permissions.owner?.id
+    return Boolean(this.map.options.user?.is_owner)
   }
 
   isAnonymousMap() {

--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -640,7 +640,7 @@ const ControlsMixin = {
       L.DomEvent.on(shareStatusButton, 'click', this.permissions.edit, this.permissions)
     }
     this.on('postsync', L.bind(update, this))
-    if (this.options.user) {
+    if (this.options.user?.id) {
       L.DomUtil.createLink(
         'umap-user',
         rightContainer,

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -393,7 +393,7 @@ U.Map = L.Map.extend({
     this._controls.search = new U.SearchControl()
     this._controls.embed = new L.Control.Embed(this)
     this._controls.tilelayersChooser = new U.TileLayerChooser(this)
-    if (this.options.user) this._controls.star = new U.StarControl(this)
+    if (this.options.user?.id) this._controls.star = new U.StarControl(this)
     this._controls.editinosm = new L.Control.EditInOSM({
       position: 'topleft',
       widgetOptions: {
@@ -1048,7 +1048,15 @@ U.Map = L.Map.extend({
     if (error) {
       return
     }
-
+    if (data.login_required) {
+      window.onLogin = () => this.saveSelf()
+      window.open(data.login_required)
+      return
+    }
+    if (data.user?.id) {
+      this.options.user = data.user
+      this.renderEditToolbar()
+    }
     if (!this.options.umap_id) {
       this.options.umap_id = data.id
       this.permissions.setOptions(data.permissions)

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -1638,11 +1638,13 @@ U.Map = L.Map.extend({
   },
 
   del: async function () {
-    if (confirm(L._('Are you sure you want to delete this map?'))) {
-      const url = this.urls.get('map_delete', { map_id: this.options.umap_id })
-      const [data, response, error] = await this.server.post(url)
-      if (data.redirect) window.location = data.redirect
-    }
+    this.dialog
+      .confirm(L._('Are you sure you want to delete this map?'))
+      .then(async () => {
+        const url = this.urls.get('map_delete', { map_id: this.options.umap_id })
+        const [data, response, error] = await this.server.post(url)
+        if (data.redirect) window.location = data.redirect
+      })
   },
 
   clone: async function () {

--- a/umap/templates/registration/login.html
+++ b/umap/templates/registration/login.html
@@ -1,5 +1,10 @@
 {% extends "base.html" %}
 
+{% load i18n %}
+
+{% block head_title %}
+  {% trans "Login" %}
+{% endblock head_title %}
 {% load umap_tags i18n %}
 
 {% block extra_head %}

--- a/umap/templates/umap/login_popup_end.html
+++ b/umap/templates/umap/login_popup_end.html
@@ -5,10 +5,13 @@
 </h3>
 <script type="text/javascript">
   function proceed() {
-    if (window.opener && window.opener.umap_proceed) {
-      window.opener.umap_proceed()
+    if (window.opener?.onLogin) {
+      // We are in the normal process login
+      window.opener.onLogin()
+      window.close()
     } else {
-      // Trade off as Twitter does not allow us to access window.opener
+      // we may be in login process that includes a magic link, so user
+      // has opened a new window from this link, and we cannot close it then.
       window.location.href = '{% url "user_dashboard" %}'
     }
   }

--- a/umap/tests/integration/test_owned_map.py
+++ b/umap/tests/integration/test_owned_map.py
@@ -134,17 +134,9 @@ def test_owner_has_delete_map_button(map, live_server, login):
     advanced.click()
     delete = page.get_by_role("button", name="Delete", exact=True)
     expect(delete).to_be_visible()
-    dialog_shown = False
-
-    def handle_dialog(dialog):
-        dialog.accept()
-        nonlocal dialog_shown
-        dialog_shown = True
-
-    page.on("dialog", handle_dialog)
+    delete.click()
     with page.expect_navigation():
-        delete.click()
-    assert dialog_shown
+        page.get_by_role("button", name="OK").click()
     assert Map.objects.all().count() == 0
 
 

--- a/umap/views.py
+++ b/umap/views.py
@@ -458,12 +458,16 @@ def simple_json_response(**kwargs):
 
 class SessionMixin:
     def get_user_data(self):
+        data = {}
+        if hasattr(self, "object"):
+            data["is_owner"] = self.object.is_owner(self.request.user, self.request)
         if self.request.user.is_anonymous:
-            return {}
+            return data
         return {
             "id": self.request.user.pk,
             "name": str(self.request.user),
             "url": reverse("user_dashboard"),
+            **data,
         }
 
 


### PR DESCRIPTION
This:
- catch "login_required" from the map page, when hitting the save button
- proceed the save and close the login page at the end of the login process
- make sure to update the map user after a save

It's not ideal because when the save process includes a magic link (which can be the case with MonComptePro eg.), the new window will never be closed, and the save will not proceed, so the user will have to close the new window and click save again. Then the map will save and the user name will be shown in the edit toolbar as normal.

But that's the better compromise I can get to…