### PR TITLE
feat: allow to star a map from query string

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -306,6 +306,13 @@ U.Map = L.Map.extend({
     if (this.options.noControl) return
     if (L.Util.queryString('share')) {
       this.share.open()
+    } else if (L.Util.queryString('download')) {
+      const download_url = this.urls.get('map_download', {
+        map_id: this.options.umap_id,
+      })
+      window.location = download_url
+    } else if (L.Util.queryString('star')) {
+      await this.star()
     } else if (this.options.onLoadPanel === 'databrowser') {
       this.panel.setDefaultMode('expanded')
       this.openBrowser('data')
@@ -330,12 +337,6 @@ U.Map = L.Map.extend({
       const url = new URL(window.location)
       url.searchParams.delete('edit')
       history.pushState({}, '', url)
-    }
-    if (L.Util.queryString('download')) {
-      const download_url = this.urls.get('map_download', {
-        map_id: this.options.umap_id,
-      })
-      window.location = download_url
     }
   },
 


### PR DESCRIPTION
Some users hide the star button from their map (to keep the UI clean I guess), but as a uMap instance administrator I may want to star it anyway, to make it appear on the home, when using the "starred" feed, or to save a good showcase.

That's an hidden feature, but we may use it to star a map from a list at some point.