### PR TITLE
fix: deactivate loader on map fragments

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -62,8 +62,10 @@ U.Map = L.Map.extend({
       this.editPanel = new U.EditPanel(this)
       this.fullPanel = new U.FullPanel(this)
     }
-    L.DomEvent.on(document.body, 'dataloading', (e) => this.fire('dataloading', e))
-    L.DomEvent.on(document.body, 'dataload', (e) => this.fire('dataload', e))
+    if (!this.options.noControl) {
+      L.DomEvent.on(document.body, 'dataloading', (e) => this.fire('dataloading', e))
+      L.DomEvent.on(document.body, 'dataload', (e) => this.fire('dataload', e))
+    }
     this.server = new U.ServerRequest()
     this.request = new U.Request()
 


### PR DESCRIPTION
Since 8ddc570e23bc403317b0509f50580af9d077ca86 we lost the link request <=> map, so the "dataloading" and "dataload" events are global to the DOM, so when loading a list of maps, all instances react to all dataloading events, which makes the list a mess.

I'd prefer to keep this loading indicator per map, but it's much easier to just hide it, so let's go that way.