### PR TITLE
chore: bump postgis in the CI

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgis/postgis:12-2.5
+        image: postgis/postgis:13-3.4
         ports:
           - 5432:5432
         env:


### PR DESCRIPTION
So to bump PostgreSQL to 13, and make Django 5.1 happy