### PR TITLE
wip: use CircleMarker instead of Circle icon

### DIFF
--- a/umap/static/umap/js/modules/data/features.js
+++ b/umap/static/umap/js/modules/data/features.js
@@ -14,6 +14,7 @@ import {
   LeafletPolyline,
   LeafletPolygon,
   MaskPolygon,
+  CircleMarker,
 } from '../rendering/ui.js'
 import loadPopup from '../rendering/popup.js'
 
@@ -602,6 +603,7 @@ export class Point extends Feature {
   }
 
   getUIClass() {
+    if (this.getOption('iconClass') === 'Circle') return CircleMarker
     return super.getUIClass() || LeafletMarker
   }
 

--- a/umap/static/umap/js/modules/schema.js
+++ b/umap/static/umap/js/modules/schema.js
@@ -407,6 +407,13 @@ export const SCHEMA = {
     ],
     default: 'Default',
   },
+  radius: {
+    type: Number,
+    default: 4,
+    impacts: ['data'],
+    label: translate('Radius in px'),
+    inheritable: true,
+  },
   remoteData: {
     type: Object,
     impacts: ['remote-data'],


### PR DESCRIPTION
This needs more work, but would allow:
- better performance: - one svg for all features instead of one HTML per feature - as it inherits from path, only visible feature are added to DOM
- controling the circle radius, which is something requested from time to time

To move forward, we need:

- [ ] to have default per UI class (instead of in the SCHEMA), as for example we do not want the same default weight for a line or for the CircleMarker
- [ ] maybe to have some static properties, so to keep the circle border color always white, as now (but can be discussed)
- [ ] when editing a feature, to show properties according to the current selected UI class, so user can define the radius when "Circle" is selected, but also other path related properties (fillColor, opacity…)