### PR TITLE
fix: remove position fixed for input and textarea in tableeditor

### DIFF
--- a/umap/static/umap/css/tableeditor.css
+++ b/umap/static/umap/css/tableeditor.css
@@ -56,8 +56,6 @@
 .umap-table-editor textarea,
 .umap-table-editor input[type=text] {
     border-radius: initial;
-    width: initial;
-    position: fixed;
 }
 .umap-table-editor th button {
     transform: rotate(90deg);


### PR DESCRIPTION
Otherwise when scrolling the table, the input will not appear at the expected position, and may even appear outside of the view when the table is bigger than the viewport.

Drawback: the table will resize its columns when the input/textarea is created (as block is in the flow). So I've also removed the width reset.

fix #2071