### PR TITLE
feat: add more context in overpass importer autocomplete results

### DIFF
--- a/umap/static/umap/js/modules/importers/overpass.js
+++ b/umap/static/umap/js/modules/importers/overpass.js
@@ -25,10 +25,20 @@ class Autocomplete extends SingleMixin(BaseAjax) {
   }
 
   createResult(item) {
+    const labels = [item.properties.name]
+    if (item.properties.county) {
+      labels.push(item.properties.county)
+    }
+    if (item.properties.state) {
+      labels.push(item.properties.state)
+    }
+    if (item.properties.country) {
+      labels.push(item.properties.country)
+    }
     return super.createResult({
       // Overpass convention to get their id from an osm one.
       value: item.properties.osm_id + 3600000000,
-      label: `${item.properties.name}`,
+      label: labels.join(', '),
     })
   }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d2309cf2-1f74-4932-af49-9471a456ed15)

(instead of a long list of "Orange"…)