### PR TITLE
fix: make sure datalayersControl=expanded does not override onLoadPanel

### DIFF
--- a/umap/static/umap/js/modules/schema.js
+++ b/umap/static/umap/js/modules/schema.js
@@ -81,7 +81,7 @@ export const SCHEMA = {
     impacts: ['ui'],
     nullable: true,
     handler: 'DataLayersControl',
-    label: translate('Display the data layers control'),
+    label: translate('Display the open browser control'),
     default: true,
   },
   defaultView: {

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -144,7 +144,10 @@ U.Map = L.Map.extend({
       delete this.options.displayDataBrowserOnLoad
     }
     if (this.options.datalayersControl === 'expanded') {
-      this.options.onLoadPanel = 'datalayers'
+      if (!this.options.onLoadPanel) {
+        this.options.onLoadPanel = 'datalayers'
+      }
+      delete this.options.datalayersControl
     }
     if (this.options.onLoadPanel === 'facet') {
       this.options.onLoadPanel = 'datafilters'
@@ -280,7 +283,9 @@ U.Map = L.Map.extend({
     // Specific case for datalayersControl
     // which accepts "expanded" value, on top of true/false/null
     if (L.Util.queryString('datalayersControl') === 'expanded') {
-      options.onLoadPanel = 'datalayers'
+      if (!options.onLoadPanel) {
+        options.onLoadPanel = 'datalayers'
+      }
     }
   },
 

--- a/umap/tests/integration/test_edit_datalayer.py
+++ b/umap/tests/integration/test_edit_datalayer.py
@@ -114,7 +114,7 @@ def test_can_change_icon_class(live_server, openmap, page):
 
 def test_can_change_name(live_server, openmap, page, datalayer):
     page.goto(
-        f"{live_server.url}{openmap.get_absolute_url()}?edit&datalayersControl=expanded"
+        f"{live_server.url}{openmap.get_absolute_url()}?edit&onLoadPanel=databrowser"
     )
     page.get_by_role("link", name="Manage layers").click()
     page.locator(".panel.right").get_by_title("Edit", exact=True).click()
@@ -133,7 +133,7 @@ def test_can_change_name(live_server, openmap, page, datalayer):
 
 def test_can_create_new_datalayer(live_server, openmap, page, datalayer):
     page.goto(
-        f"{live_server.url}{openmap.get_absolute_url()}?edit&datalayersControl=expanded"
+        f"{live_server.url}{openmap.get_absolute_url()}?edit&onLoadPanel=databrowser"
     )
     page.get_by_role("link", name="Manage layers").click()
     page.get_by_role("button", name="Add a layer").click()

--- a/umap/tests/integration/test_querystring.py
+++ b/umap/tests/integration/test_querystring.py
@@ -33,6 +33,13 @@ def test_datalayers_control(map, live_server, datalayer, page):
     page.goto(f"{live_server.url}{map.get_absolute_url()}?datalayersControl=expanded")
     expect(control).to_be_visible()
     expect(browser).to_be_visible()
+    # Should not override onLoadPanel
+    page.goto(
+        f"{live_server.url}{map.get_absolute_url()}?datalayersControl=expanded&onLoadPanel=caption"
+    )
+    expect(control).to_be_visible()
+    expect(browser).to_be_hidden()
+    expect(page.locator(".umap-caption")).to_be_visible()
 
 
 def test_can_deactivate_wheel_from_query_string(map, live_server, page):


### PR DESCRIPTION
This value of datalayersControl exists for retrocompat only (it's now replaced by onLoadPanel=browser)