### PR TITLE
fix: do not fail when trying to edit a circlemarker

### DIFF
--- a/umap/static/umap/js/modules/data/features.js
+++ b/umap/static/umap/js/modules/data/features.js
@@ -98,6 +98,10 @@ class Feature {
     this.pushGeometry()
   }
 
+  isOnScreen() {
+    return this.ui?.isOnScreen()
+  }
+
   pushGeometry() {
     this.ui.setLatLngs(this.toLatLngs())
   }
@@ -257,7 +261,7 @@ class Feature {
       builder.helpers['properties.name'].input.focus()
     })
     this.map.editedFeature = this
-    if (!this.isOnScreen()) this.zoomTo(event)
+    if (!this.ui.isOnScreen()) this.zoomTo(event)
   }
 
   getAdvancedEditActions(container) {
@@ -661,11 +665,6 @@ export class Point extends Feature {
       super.zoomTo(event)
     }
   }
-
-  isOnScreen(bounds) {
-    bounds = bounds || this.map.getBounds()
-    return bounds.contains(this.toLatLngs())
-  }
 }
 
 class Path extends Feature {
@@ -751,11 +750,6 @@ class Path extends Feature {
       items.push(U.ExtractShapeFromMultiAction)
     }
     return items
-  }
-
-  isOnScreen(bounds) {
-    bounds = bounds || this.map.getBounds()
-    return bounds.overlaps(this.bounds)
   }
 
   zoomTo({ easing, callback }) {

--- a/umap/static/umap/js/modules/rendering/ui.js
+++ b/umap/static/umap/js/modules/rendering/ui.js
@@ -146,9 +146,16 @@ const FeatureMixin = {
   getPopupToolbarAnchor: () => [0, 0],
 }
 
+const PointMixin = {
+  isOnScreen: function (bounds) {
+    bounds = bounds || this._map.getBounds()
+    return bounds.contains(this.getCenter())
+  },
+}
+
 export const LeafletMarker = Marker.extend({
   parentClass: Marker,
-  includes: [FeatureMixin],
+  includes: [FeatureMixin, PointMixin],
 
   initialize: function (feature, latlng) {
     FeatureMixin.initialize.call(this, feature, latlng)
@@ -411,6 +418,11 @@ const PathMixin = {
     'dashArray',
     'interactive',
   ],
+
+  isOnScreen: function (bounds) {
+    bounds = bounds || this._map.getBounds()
+    return bounds.overlaps(this.getBounds())
+  },
 }
 
 export const LeafletPolyline = Polyline.extend({
@@ -552,7 +564,7 @@ export const MaskPolygon = LeafletPolygon.extend({
 
 export const CircleMarker = BaseCircleMarker.extend({
   parentClass: BaseCircleMarker,
-  includes: [FeatureMixin, PathMixin],
+  includes: [FeatureMixin, PathMixin, PointMixin],
   initialize: function (feature, latlng) {
     if (Array.isArray(latlng) && !(latlng[0] instanceof Number)) {
       // Must be a line or polygon
@@ -570,4 +582,8 @@ export const CircleMarker = BaseCircleMarker.extend({
   getCenter: function () {
     return this._latlng
   },
+  // FIXME when Leaflet.Editable knows about CircleMarker
+  editEnabled: () => false,
+  enableEdit: () => {}, // No-op
+  disableEdit: () => {}, // No-op
 })


### PR DESCRIPTION
And for now open the properties panel (geometry/position may be edited later, when Leaflet.Editable knows about CircleMarker)