### PR TITLE
fix: feature.isOnScreen is now passing the "bounds" argument

### DIFF
--- a/umap/static/umap/js/modules/data/features.js
+++ b/umap/static/umap/js/modules/data/features.js
@@ -98,8 +98,8 @@ class Feature {
     this.pushGeometry()
   }
 
-  isOnScreen() {
-    return this.ui?.isOnScreen()
+  isOnScreen(bounds) {
+    return this.ui?.isOnScreen(bounds)
   }
 
   pushGeometry() {
@@ -261,7 +261,7 @@ class Feature {
       builder.helpers['properties.name'].input.focus()
     })
     this.map.editedFeature = this
-    if (!this.ui.isOnScreen()) this.zoomTo(event)
+    if (!this.ui.isOnScreen(this.map.getBounds())) this.zoomTo(event)
   }
 
   getAdvancedEditActions(container) {

--- a/umap/static/umap/js/modules/rendering/ui.js
+++ b/umap/static/umap/js/modules/rendering/ui.js
@@ -105,7 +105,7 @@ const FeatureMixin = {
       text: translate('Copy as GeoJSON'),
       callback: () => {
         L.Util.copyToClipboard(JSON.stringify(this.feature.toGeoJSON()))
-        this._map.tooltip.open({content: L._('Copied!')})
+        this._map.tooltip.open({ content: L._('Copied!') })
       },
     })
     if (this._map.editEnabled && !this.feature.isReadOnly()) {
@@ -156,7 +156,6 @@ const FeatureMixin = {
 
 const PointMixin = {
   isOnScreen: function (bounds) {
-    bounds = bounds || this._map.getBounds()
     return bounds.contains(this.getCenter())
   },
 }
@@ -428,7 +427,6 @@ const PathMixin = {
   ],
 
   isOnScreen: function (bounds) {
-    bounds = bounds || this._map.getBounds()
     return bounds.overlaps(this.getBounds())
   },
 }


### PR DESCRIPTION
Otherwise, when using the browser, we'll end up using this._map.getBounds(), but in this case the UI may not be in the map (may be filtered).