### PR TITLE
fix: teams.all() called on anonymous user by mistake

### DIFF
--- a/umap/decorators.py
+++ b/umap/decorators.py
@@ -33,12 +33,11 @@ def can_edit_map(view_func):
     @wraps(view_func)
     def wrapper(request, *args, **kwargs):
         map_inst = get_object_or_404(Map, pk=kwargs["map_id"])
-        user = request.user
         kwargs["map_inst"] = map_inst  # Avoid rerequesting the map in the view
         if map_inst.edit_status >= map_inst.COLLABORATORS:
-            can_edit = map_inst.can_edit(user=user, request=request)
+            can_edit = map_inst.can_edit(request=request)
             if not can_edit:
-                if map_inst.owner and not user.is_authenticated:
+                if map_inst.owner and not request.user.is_authenticated:
                     return simple_json_response(login_required=str(LOGIN_URL))
                 return HttpResponseForbidden()
         return view_func(request, *args, **kwargs)

--- a/umap/templatetags/umap_tags.py
+++ b/umap/templatetags/umap_tags.py
@@ -45,7 +45,7 @@ def tilelayer_preview(tilelayer):
 
 @register.filter
 def can_delete_map(map, request):
-    return map.can_delete(request.user, request)
+    return map.can_delete(request)
 
 
 @register.filter

--- a/umap/tests/conftest.py
+++ b/umap/tests/conftest.py
@@ -90,3 +90,8 @@ def datalayer(map):
 @pytest.fixture
 def tilelayer():
     return TileLayerFactory()
+
+
+@pytest.fixture
+def fake_request(rf):
+    return rf.get("/")


### PR DESCRIPTION
In the same move, refactor the can_edit/_view/_delete functions to only take the request, which is what really happen in the code, and adapt the test in that way.