### PR TITLE
chore: get Github release notes from command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ tx_push:
 	tx push -s
 tx_pull:
 	tx pull
+changelog:
+	$(eval VERSION=$(shell hatch version))
+	@# Bearer token is readonly
+	@printf $(shell curl -sL -X POST -H "Authorization: Bearer ${GITHUB_TOKEN}" https://api.github.com/repos/umap-project/umap/releases/generate-notes  -d '{"target_commitish":"master","previous_tag_name":"", "tag_name": "${VERSION}"}' | jq .body | sed 's/https:\/\/github.com\/umap-project\/umap\/pull\//#/g')
 
 jsdir = umap/static/umap/js/
 filepath = "${jsdir}*.js"

--- a/docs/release.md
+++ b/docs/release.md
@@ -22,10 +22,11 @@
     - commit new translations `git commit -am "i18n"`
 2. Test collectstatic: `umap collectstatic --no-input`
 2. Bump version: `make patch|minor`
+2. Ask automatic release notes to Github: `make changelog` and paste it in `docs/changelog.md`
 3. `git commit -am "2.X.Y"`
 4. `git tag 2.X.Y`
 5. `git push && git push --tag`
-6. Go to [Github release page](https://github.com/umap-project/umap/releases/new) and Generate release notes + paste it in `docs/changelog.md` + finish Github process for a new release
+6. Go to [Github release page](https://github.com/umap-project/umap/releases/new) and paste release notes
 7. Commit the changelog `git commit -am "changelog"`
 8. `make build`
 9. `make publish`


### PR DESCRIPTION
So we can integrate the changelog in the release, instead of having a commit after the release.

You need to have a GITHUB_TOKEN env var, with a read only bearer coming from https://github.com/settings/tokens