### PR TITLE
feat: add a setting to prevent users from editing their profile

### DIFF
--- a/docs/config/settings.md
+++ b/docs/config/settings.md
@@ -144,6 +144,12 @@ Should uMap allows user without an account to create maps (default is False).
 
 Can be set through env var: `UMAP_ALLOW_ANONYMOUS=1`
 
+#### UMAP_ALLOW_EDIT_PROFILE
+
+Should uMap allows users to edit their profile (default is True).
+
+Can be unset through env var: `UMAP_ALLOW_EDIT_PROFILE=0`
+
 #### UMAP_CUSTOM_TEMPLATES
 To be used when you want to override some HTML templates:
 

--- a/umap/context_processors.py
+++ b/umap/context_processors.py
@@ -12,6 +12,7 @@ def settings(request):
         "UMAP_READONLY": djsettings.UMAP_READONLY,
         "UMAP_DEMO_SITE": djsettings.UMAP_DEMO_SITE,
         "UMAP_HOST_INFOS": djsettings.UMAP_HOST_INFOS,
+        "UMAP_ALLOW_EDIT_PROFILE": djsettings.UMAP_ALLOW_EDIT_PROFILE,
     }
 
 

--- a/umap/settings/base.py
+++ b/umap/settings/base.py
@@ -240,6 +240,7 @@ USER_URL_FIELD = "username"
 # Miscellaneous project settings
 # =============================================================================
 UMAP_ALLOW_ANONYMOUS = env.bool("UMAP_ALLOW_ANONYMOUS", default=False)
+UMAP_ALLOW_EDIT_PROFILE = env.bool("UMAP_ALLOW_EDIT_PROFILE", default=True)
 
 UMAP_EXTRA_URLS = {
     "routing": "http://www.openstreetmap.org/directions?engine=osrm_car&route={lat},{lng}&locale={locale}#map={zoom}/{lat}/{lng}",  # noqa

--- a/umap/templates/umap/dashboard_menu.html
+++ b/umap/templates/umap/dashboard_menu.html
@@ -7,8 +7,10 @@
     {% else %}
       <a href="{% url 'user_dashboard' %}">{% trans "My Maps" %}</a>
     {% endif %}
-    <a {% if selected == "profile" %}class="selected"{% endif %}
-       href="{% url 'user_profile' %}">{% trans "My profile" %}</a>
+    {% if UMAP_ALLOW_EDIT_PROFILE %}
+      <a {% if selected == "profile" %}class="selected"{% endif %}
+         href="{% url 'user_profile' %}">{% trans "My profile" %}</a>
+    {% endif %}
     <a {% if selected == "teams" %}class="selected"{% endif %}
        href="{% url 'user_teams' %}">{% trans "My teams" %}</a>
   </h2>

--- a/umap/urls.py
+++ b/umap/urls.py
@@ -115,11 +115,15 @@ i18n_urls += decorated_patterns(
         name="map_star",
     ),
     path("me", views.user_dashboard, name="user_dashboard"),
-    path("me/profile", views.user_profile, name="user_profile"),
     path("me/download", views.user_download, name="user_download"),
     path("me/teams", views.UserTeams.as_view(), name="user_teams"),
     path("team/create/", views.TeamNew.as_view(), name="team_new"),
 )
+
+if settings.UMAP_ALLOW_EDIT_PROFILE:
+    i18n_urls.append(
+        path("me/profile", login_required(views.user_profile), name="user_profile")
+    )
 i18n_urls += decorated_patterns(
     [login_required, team_members_only],
     path("team/<int:pk>/edit/", views.TeamUpdate.as_view(), name="team_update"),


### PR DESCRIPTION
In some situations, the profile comes from the OAuth provider and shouldn’t be modified by users.