### PR TITLE
fix: editing coordinates manually would not be saved

### DIFF
--- a/umap/static/umap/js/modules/data/features.js
+++ b/umap/static/umap/js/modules/data/features.js
@@ -655,6 +655,7 @@ export class Point extends Feature {
           builder.restoreField('ui._latlng.lat')
           builder.restoreField('ui._latlng.lng')
         }
+        this.pullGeometry()
         this.zoomTo({ easing: false })
       },
     })


### PR DESCRIPTION
The primary coordinates is a two-elements Array in Point.coordinates, but FormBuilder does not know how to edit an Array, so we edit the `ui._latlngs` instead.

The proper fix would have been to teach FormBuilder how to edit an Array, but that path is way longer, and given we plan to refactor it totally, let's wait for that.

fix #2144