### PR TITLE
fix: polygon with interactive=false was still interactive

### DIFF
--- a/umap/static/umap/js/modules/rendering/ui.js
+++ b/umap/static/umap/js/modules/rendering/ui.js
@@ -344,6 +344,10 @@ const PathMixin = {
     }
     options.pointerEvents = options.interactive ? 'visiblePainted' : 'stroke'
     this.parentClass.prototype.setStyle.call(this, options)
+    // TODO remove me when this gets merged and released:
+    // https://github.com/Leaflet/Leaflet/pull/9475
+
+    this._path.classList.toggle('leaflet-interactive', options.interactive)
   },
 
   _redraw: function () {


### PR DESCRIPTION
This bug has been introduced when spliting features, as we now only set the Leaflet Polygon options with setStyle, will the `interactive` option is only used in the init by Leaflet.

See https://github.com/Leaflet/Leaflet/pull/9475