### PR TITLE
Update 3-create-account.md

### DIFF
--- a/docs-users/fr/tutorials/3-create-account.md
+++ b/docs-users/fr/tutorials/3-create-account.md
@@ -67,9 +67,11 @@ récipiendaires ne pourront pas modifier vos cartes.
 3. Sur [le site uMap pour les agents publics](https://umap.incubateur.anct.gouv.fr/fr/),
    cliquez sur `Me Connecter`.
 
-Le tableau de bord s’ouvre, il  affiche l’ensemble des cartes que
+Le tableau de bord s’ouvre, il affiche l’ensemble des cartes que
 vous créez ainsi que les équipes auxquelles vous participez.
 
+!!! note pour les agents publics 
+    Associer une carte à une équipe vous permet d'afficher le nom de cette équipe au lieu du vôtre sur une carte (noms de votre commune, de votre service...). Une équipe peut se composer d'une seule personne. 
 
 ### 2. Créer une équipe
 
@@ -99,3 +101,4 @@ puis sur cliquez sur « Editer » et cliquez en haut de page
 à droite du titre sur « Visibilité : Définir qui peut voir et modifier la carte ».
 
 ![Panneau de permissions pour la sélection des équipes](../../static/tutoriels/my-teams-permissions.png)
+


### PR DESCRIPTION
Add information 
Note for public officials: associating a card with a team allows you to display the team's name instead of your own (city, department). A team can consist of a single person