### PR TITLE
chore(deploy): Spawn the websocket server in the docker image.

### DIFF
--- a/docker/uwsgi.ini
+++ b/docker/uwsgi.ini
@@ -10,3 +10,17 @@ enable-threads = true
 static-map = /static=/srv/umap/static
 static-map = /uploads=/srv/umap/uploads
 buffer-size = 32768
+
+; Run the websocket server only when the env variable
+; WEBSOCKET_ENABLED is set to True.
+; This is enough for the base docker image, but does not
+; take into account the settings as the source of truth.
+if-env = WEBSOCKET_ENABLED
+websocket_enabled = %(_)
+endif =
+
+if-opt = websocket_enabled=True
+print = Starting the Websocket Server (WEBSOCKET_ENABLED=%(websocket_enabled))
+attach-daemon = umap run_websocket_server
+endif =
+lazy-apps = true


### PR DESCRIPTION
Checks if the `WEBSOCKET_ENABLED` is set to `True` and runs the websocket server accordingly.