### PR TITLE
clean: remove zoom in and out from contextmenu

### DIFF
--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -1686,20 +1686,7 @@ U.Map = L.Map.extend({
 
   getContextMenuItems: function (event) {
     const items = []
-    if (this._zoom !== this.getMaxZoom()) {
-      items.push({
-        label: L._('Zoom in'),
-        action: () => this.zoomIn(),
-      })
-    }
-    if (this._zoom !== this.getMinZoom()) {
-      items.push({
-        label: L._('Zoom out'),
-        action: () => this.zoomOut(),
-      })
-    }
     if (this.hasEditMode()) {
-      items.push('-')
       if (this.editEnabled) {
         if (!this.isDirty) {
           items.push({


### PR DESCRIPTION
Let's make it smaller (unless proven otherwise!).