### PR TITLE
tests: use `at.least` to compare dates on the hlc tests.

### DIFF
--- a/umap/static/umap/unittests/hlc.js
+++ b/umap/static/umap/unittests/hlc.js
@@ -100,7 +100,12 @@ describe('HybridLogicalClock', () => {
       clock = new HybridLogicalClock(now, 5, 'local')
       const result = clock.receive(`${now - 1000}:7:remote`)
       expect(result.walltime).to.be.least(now)
-      expect(result.nn).to.equal(6)
+      if (result.walltime > now) {
+        expect(result.nn).to.equal(5)
+      }
+      else {
+        expect(result.nn).to.equal(6)
+      }
       expect(result.id).to.equal('local')
     })
   })

--- a/umap/static/umap/unittests/hlc.js
+++ b/umap/static/umap/unittests/hlc.js
@@ -81,7 +81,7 @@ describe('HybridLogicalClock', () => {
       const now = Date.now()
       clock = new HybridLogicalClock(now, 5, 'local')
       const result = clock.receive(`${now}:7:remote`)
-      expect(result.walltime).to.equal(now)
+      expect(result.walltime).to.be.at.least(now)
       expect(result.nn).to.equal(8)
       expect(result.id).to.equal('local')
     })
@@ -117,7 +117,7 @@ describe('HybridLogicalClock', () => {
     const event2 = hlc.tick()
 
     // Simulate receiving a message from another node
-    const remoteEvent = hlc.receive(`${Date.now() - 50}:5:remote-id`)
+    hlc.receive(`${Date.now() - 50}:5:remote-id`)
 
     const event3 = hlc.tick()
 


### PR DESCRIPTION
Should fix [this error](https://github.com/umap-project/umap/actions/runs/11165503827/job/31037336947?pr=2188)