### PR TITLE
fix: honour carriage returns in permanent credits

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -453,17 +453,13 @@ U.PermanentCreditsControl = L.Control.extend({
   },
 
   onAdd: function () {
-    const paragraphContainer = L.DomUtil.create(
+    this.paragraphContainer = L.DomUtil.create(
       'div',
-      'umap-permanent-credits-container'
+      'umap-permanent-credits-container text'
     )
-    const creditsParagraph = L.DomUtil.create('p', '', paragraphContainer)
-
-    this.paragraphContainer = paragraphContainer
     this.setCredits()
     this.setBackground()
-
-    return paragraphContainer
+    return this.paragraphContainer
   },
 
   setCredits: function () {


### PR DESCRIPTION
fix #2197

The fix here is to add the `text` class, the rest is cleaning.