### PR TITLE
chore: simplify contextmenu items

### DIFF
--- a/umap/static/umap/js/modules/rendering/ui.js
+++ b/umap/static/umap/js/modules/rendering/ui.js
@@ -86,8 +86,9 @@ const FeatureMixin = {
 
   onContextMenu: function (event) {
     DomEvent.stop(event)
-    const items = this._map.getContextMenuItems(event)
-    items.push('-', ...this.feature.getContextMenuItems(event))
+    const items = this.feature
+      .getContextMenuItems(event)
+      .concat(this._map.getContextMenuItems(event))
     this._map.contextmenu.open(event.originalEvent, items)
   },
 

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -1688,7 +1688,7 @@ U.Map = L.Map.extend({
     this.loader.onAdd(this)
   },
 
-  getContextMenuItems: function (event) {
+  getOwnContextMenuItems: function (event) {
     const items = []
     if (this.hasEditMode()) {
       if (this.editEnabled) {
@@ -1757,6 +1757,11 @@ U.Map = L.Map.extend({
         action: () => this.search(),
       }
     )
+    return items
+  },
+
+  getContextMenuItems: function (event) {
+    const items = []
     if (this.options.urls.routing) {
       items.push('-', {
         label: L._('Directions from here'),
@@ -1773,7 +1778,9 @@ U.Map = L.Map.extend({
   },
 
   onContextMenu: function (event) {
-    const items = this.getContextMenuItems(event)
+    const items = this.getOwnContextMenuItems(event).concat(
+      this.getContextMenuItems(event)
+    )
     this.contextmenu.open(event.originalEvent, items)
   },
 


### PR DESCRIPTION
Do not show generic map items when clicking on a feature.

cf #2109

Click on map:

![image](https://github.com/user-attachments/assets/b3717d4a-6f6c-4976-a86b-f97bd1239cea)

Click on feature:

![image](https://github.com/user-attachments/assets/c7f75afb-4a8a-446a-b7f4-a4a790c148c3)
