### PR TITLE
fix: do not show browser counter when layer is empty or not loaded

### DIFF
--- a/umap/static/umap/js/modules/browser.js
+++ b/umap/static/umap/js/modules/browser.js
@@ -98,6 +98,7 @@ export default class Browser {
     datalayer.eachFeature((feature) => this.addFeature(feature, container))
 
     const total = datalayer.count()
+    if (!total) return
     const current = container.querySelectorAll('li').length
     const count = total === current ? total : `${current}/${total}`
     const counter = DomUtil.create('span', 'datalayer-counter', headline)


### PR DESCRIPTION
fix #2215