### PR TITLE
Docker: `version` is obsolete.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,9 @@
-version: '3'
-
 services:
 
   db:
     healthcheck:
-        test: ["CMD-SHELL", "pg_isready -U postgres"]
-        interval: 2s
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 2s
     image: postgis/postgis:14-3.3-alpine
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -3,7 +3,6 @@
 An official uMap docker image is [available on the docker hub](https://hub.docker.com/r/umap/umap). But, if you prefer to run it with docker compose, here is the configuration file:
 
 ```yaml title="docker-compose.yml"
-version: '3'
 services:
   db:
     # check https://hub.docker.com/r/postgis/postgis to see available versions


### PR DESCRIPTION
The top-level 'version' property is deprecated and can be omitted to prevent warnings.