### PR TITLE
fix: fix dispeared icons from panel titles

### DIFF
--- a/umap/static/umap/js/umap.core.js
+++ b/umap/static/umap/js/umap.core.js
@@ -143,7 +143,7 @@ L.DomUtil.createButtonIcon = (parent, className, title, callback, size = 16) => 
 
 L.DomUtil.createTitle = (parent, text, iconClassName, className = '', tag = 'h3') => {
   const title = L.DomUtil.create(tag, '', parent)
-  if (className) L.DomUtil.createIcon(title, iconClassName)
+  if (iconClassName) L.DomUtil.createIcon(title, iconClassName)
   L.DomUtil.add('span', className, title, text)
   return title
 }


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/54a7de1e-790a-46a2-aa0c-0acb03286349)


After:

![image](https://github.com/user-attachments/assets/f57bb884-a748-4aa4-9153-707b201909fe)
