### PR TITLE
chore: explicitely add geojson extension when downloading a layer

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -802,7 +802,7 @@ export class DataLayer {
       this
     )
     if (this.umap_id) {
-      const filename = Utils.slugify(this.options.name)
+      const filename = `${Utils.slugify(this.options.name)}.geojson`
       const download = Utils.loadTemplate(`
         <a class="button" href="${this._dataUrl()}" download="${filename}">
           <i class="icon icon-24 icon-download"></i>${translate('Download')}


### PR DESCRIPTION
This was added by the browser I think, but let's be explicit, just in case.

cf https://github.com/umap-project/umap/pull/2224#pullrequestreview-2382243375