### PR TITLE
feat(sync): Reconnect the websocket on failures.

### DIFF
--- a/umap/static/umap/js/modules/sync/engine.js
+++ b/umap/static/umap/js/modules/sync/engine.js
@@ -91,6 +91,7 @@ export class SyncEngine {
     this._reconnectTimeout = null;
     this._reconnectDelay = RECONNECT_DELAY;
     this.websocketConnected = true;
+    this.updaters.map.update({ key: 'numberOfConnectedPeers' })
   }
 
   reconnect() {
@@ -102,6 +103,7 @@ export class SyncEngine {
       if (this._reconnectDelay < MAX_RECONNECT_DELAY) {
         this._reconnectDelay = this._reconnectDelay * RECONNECT_DELAY_FACTOR
       }
+      console.log("reconnecting now")
       this.authenticate()
     }, this._reconnectDelay);
   }

--- a/umap/static/umap/js/modules/sync/engine.js
+++ b/umap/static/umap/js/modules/sync/engine.js
@@ -70,6 +70,7 @@ export class SyncEngine {
    * Authenticate with the server and start the transport layer.
    */
   async authenticate() {
+    console.log("authenticating")
     const [response, _, error] = await this._server.get(this._websocketTokenURI)
     if (!error) {
       this.start(response.token)

--- a/umap/static/umap/js/modules/sync/websocket.js
+++ b/umap/static/umap/js/modules/sync/websocket.js
@@ -1,5 +1,6 @@
 const PONG_TIMEOUT = 5000;
 const PING_INTERVAL = 30000;
+const FIRST_CONNECTION_TIMEOUT = 2000;
 
 export class WebSocketTransport {
   constructor(webSocketURI, authToken, messagesReceiver) {
@@ -20,6 +21,13 @@ export class WebSocketTransport {
         this.receiver.reconnect()
       }
     }
+
+    this.ensureOpen = setInterval(() => {
+      if (this.websocket.readyState !== WebSocket.OPEN) {
+        this.websocket.close()
+        clearInterval(this.ensureOpen)
+      }
+    }, FIRST_CONNECTION_TIMEOUT)
 
     // To ensure the connection is still alive, we send ping and expect pong back.
     // Websocket provides a `ping` method to keep the connection alive, but it's

--- a/umap/static/umap/js/modules/sync/websocket.js
+++ b/umap/static/umap/js/modules/sync/websocket.js
@@ -1,15 +1,47 @@
+const PONG_TIMEOUT = 5000;
+const PING_INTERVAL = 30000;
+
 export class WebSocketTransport {
   constructor(webSocketURI, authToken, messagesReceiver) {
+    this.receiver = messagesReceiver
+
     this.websocket = new WebSocket(webSocketURI)
+
     this.websocket.onopen = () => {
       this.send('JoinRequest', { token: authToken })
+      this.receiver.onConnection()
     }
     this.websocket.addEventListener('message', this.onMessage.bind(this))
-    this.receiver = messagesReceiver
+    this.websocket.onclose = () => {
+      console.log("websocket closed")
+      this.receiver.reconnect()
+    }
+
+    // To ensure the connection is still alive, we send ping and expect pong back.
+    // Websocket provides a `ping` method to keep the connection alive, but it's
+    // unfortunately not possible to access it from the WebSocket object.
+    // See https://making.close.com/posts/reliable-websockets/ for more details.
+    this.pingInterval = setInterval(() => {
+      if (this.websocket.readyState === WebSocket.OPEN) {
+        this.websocket.send('ping');
+        this.pongReceived = false;
+        setTimeout(() => {
+          if (!this.pongReceived) {
+            console.warn('No pong received, reconnecting...');
+            this.websocket.close()
+            clearInterval(this.pingInterval)
+          }
+        }, PONG_TIMEOUT);
+      }
+    }, PING_INTERVAL);
   }
 
   onMessage(wsMessage) {
-    this.receiver.receive(JSON.parse(wsMessage.data))
+    if (wsMessage.data === 'pong') {
+      this.pongReceived = true;
+    } else {
+      this.receiver.receive(JSON.parse(wsMessage.data))
+    }
   }
 
   send(kind, payload) {
@@ -17,9 +49,5 @@ export class WebSocketTransport {
     message.kind = kind
     const encoded = JSON.stringify(message)
     this.websocket.send(encoded)
-  }
-
-  close() {
-    this.websocket.close()
   }
 }

--- a/umap/static/umap/js/modules/sync/websocket.js
+++ b/umap/static/umap/js/modules/sync/websocket.js
@@ -4,6 +4,7 @@ const PING_INTERVAL = 30000;
 export class WebSocketTransport {
   constructor(webSocketURI, authToken, messagesReceiver) {
     this.receiver = messagesReceiver
+    this.closeRequested = false
 
     this.websocket = new WebSocket(webSocketURI)
 
@@ -14,7 +15,10 @@ export class WebSocketTransport {
     this.websocket.addEventListener('message', this.onMessage.bind(this))
     this.websocket.onclose = () => {
       console.log("websocket closed")
-      this.receiver.reconnect()
+      if (!this.closeRequested) {
+        console.log("Not requested, reconnecting...")
+        this.receiver.reconnect()
+      }
     }
 
     // To ensure the connection is still alive, we send ping and expect pong back.
@@ -49,5 +53,10 @@ export class WebSocketTransport {
     message.kind = kind
     const encoded = JSON.stringify(message)
     this.websocket.send(encoded)
+  }
+
+  close() {
+    this.closeRequested = true
+    this.websocket.close()
   }
 }

--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -661,30 +661,43 @@ const ControlsMixin = {
       })
     }
 
-    const connectedPeers = this.sync.getNumberOfConnectedPeers()
-    if (connectedPeers !== 0) {
-      const connectedPeersCount = L.DomUtil.createButton(
-        'leaflet-control-connected-peers',
-        rightContainer,
-        ''
-      )
-      L.DomEvent.on(connectedPeersCount, 'mouseover', () => {
-        this.tooltip.open({
-          content: L._('{connectedPeers} peer(s) currently connected to this map', {
-            connectedPeers: connectedPeers,
-          }),
-          anchor: connectedPeersCount,
-          position: 'bottom',
-          delay: 500,
-          duration: 5000,
-        })
-      })
+    if (this.options.syncEnabled) {
+      const connectedPeers = this.sync.getNumberOfConnectedPeers()
+      let hoverMessage = ''
 
-      const updateConnectedPeersCount = () => {
-        connectedPeersCount.innerHTML =
-          '<span>' + this.sync.getNumberOfConnectedPeers() + '</span>'
+      if (connectedPeers !== 0 || !this.sync.websocketConnected) {
+        const connectedPeersCount = L.DomUtil.createButton(
+          'leaflet-control-connected-peers',
+          rightContainer,
+          ''
+        )
+        if (this.sync.websocketConnected) {
+          connectedPeersCount.innerHTML =
+            '<span>' + this.sync.getNumberOfConnectedPeers() + '</span>'
+          hoverMessage = L._(
+            '{connectedPeers} peer(s) currently connected to this map',
+            {
+              connectedPeers: connectedPeers,
+            }
+          )
+        } else {
+          connectedPeersCount.innerHTML = '<span>' + L._('Disconnected') + '</span>'
+          connectedPeersCount.classList.add('disconnected')
+          hoverMessage = L._('Reconnecting in {seconds} seconds', {
+            seconds: this.sync._reconnectDelay / 1000,
+          })
+        }
+
+        L.DomEvent.on(connectedPeersCount, 'mouseover', () => {
+          this.tooltip.open({
+            content: hoverMessage,
+            anchor: connectedPeersCount,
+            position: 'bottom',
+            delay: 500,
+            duration: 5000,
+          })
+        })
       }
-      updateConnectedPeersCount()
     }
 
     this.help.getStartedLink(rightContainer)

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -30,8 +30,6 @@ U.Map = L.Map.extend({
   includes: [ControlsMixin],
 
   initialize: async function (el, geojson) {
-    this.sync_engine = new U.SyncEngine(this)
-    this.sync = this.sync_engine.proxy(this)
     // Locale name (pt_PT, en_US…)
     // To be used for Django localization
     if (geojson.properties.locale) L.setLocale(geojson.properties.locale)
@@ -69,6 +67,9 @@ U.Map = L.Map.extend({
     }
     this.server = new U.ServerRequest()
     this.request = new U.Request()
+
+    this.sync_engine = new U.SyncEngine(this, this.urls, this.server)
+    this.sync = this.sync_engine.proxy(this)
 
     this.initLoader()
     this.name = this.options.name
@@ -209,10 +210,7 @@ U.Map = L.Map.extend({
     if (this.options.syncEnabled !== true) {
       this.sync.stop()
     } else {
-      const ws_token_uri = this.urls.get('map_websocket_auth_token', {
-        map_id: this.options.umap_id,
-      })
-      await this.sync.authenticate(ws_token_uri, this.options.websocketURI, this.server)
+      await this.sync.authenticate()
     }
   },
 

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -13,7 +13,7 @@ L.Map.mergeOptions({
   // we cannot rely on this because of the y is overriden by Leaflet
   // See https://github.com/Leaflet/Leaflet/pull/9201
   // And let's remove this -y when this PR is merged and released.
-  demoTileInfos: { s: 'a', z: 9, x: 265, y: 181, '-y': 181, r: '' },
+  demoTileInfos: { 's': 'a', 'z': 9, 'x': 265, 'y': 181, '-y': 181, 'r': '' },
   licences: [],
   licence: '',
   enableMarkerDraw: true,
@@ -75,7 +75,12 @@ U.Map = L.Map.extend({
     })
     const websocketURI = this.options.websocketURI
 
-    this.sync_engine = new U.SyncEngine(this, websocketTokenURI, websocketURI, this.server)
+    this.sync_engine = new U.SyncEngine(
+      this,
+      websocketTokenURI,
+      websocketURI,
+      this.server
+    )
     this.sync = this.sync_engine.proxy(this)
 
     this.initLoader()
@@ -231,6 +236,25 @@ U.Map = L.Map.extend({
   },
 
   render: function (fields) {
+    if (this.options.syncEnabled === true) {
+      if (!this.sync.websocketConnected) {
+        const template = `
+        <h3><i class="icon icon-16"></i><span>${L._('Disconnected')}</span></h3>
+        <p>
+        ${L._('This map has enabled real-time synchronization with other users, but you are currently disconnected. It will automatically reconnect when ready.')}
+        </p>
+        `
+        this.dialog.open({
+          template: template,
+          className: 'dark',
+          cancel: false,
+          accept: false,
+        })
+      } else {
+        this.dialog.close()
+      }
+    }
+
     if (fields.includes('numberOfConnectedPeers')) {
       this.renderEditToolbar()
       this.propagate()

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -68,7 +68,14 @@ U.Map = L.Map.extend({
     this.server = new U.ServerRequest()
     this.request = new U.Request()
 
-    this.sync_engine = new U.SyncEngine(this, this.urls, this.server)
+    // Store URIs to avoid persisting the map
+    // mainly to ensure separation of concerns.
+    const websocketTokenURI = this.urls.get('map_websocket_auth_token', {
+      map_id: this.options.umap_id,
+    })
+    const websocketURI = this.options.websocketURI
+
+    this.sync_engine = new U.SyncEngine(this, websocketTokenURI, websocketURI, this.server)
     this.sync = this.sync_engine.proxy(this)
 
     this.initLoader()
@@ -206,7 +213,9 @@ U.Map = L.Map.extend({
   },
 
   initSyncEngine: async function () {
+    // This.options.websocketEnabled is set by the server admin
     if (this.options.websocketEnabled === false) return
+    // This.options.syncEnabled is set by the user in the map settings
     if (this.options.syncEnabled !== true) {
       this.sync.stop()
     } else {

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -236,12 +236,14 @@ U.Map = L.Map.extend({
   },
 
   render: function (fields) {
+    console.log("sync.websocketConnected", this.sync.websocketConnected)
+    console.log("options.syncEnabled", this.options.syncEnabled)
     if (this.options.syncEnabled === true) {
-      if (!this.sync.websocketConnected) {
+      if (this.sync.websocketConnected !== true) {
         const template = `
         <h3><i class="icon icon-16"></i><span>${L._('Disconnected')}</span></h3>
         <p>
-        ${L._('This map has enabled real-time synchronization with other users, but you are currently disconnected. It will automatically reconnect when ready.')}
+        ${L._('This map has enabled real-time synchronization with other users, but you are currently disconnected.It will automatically reconnect when ready.')}
         </p>
         `
         this.dialog.open({

--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -518,6 +518,12 @@ ul.photon-autocomplete {
     background-color: var(--color-lightCyan);
     color: var(--color-dark);
 }
+.leaflet-container .leaflet-control-connected-peers.disconnected,
+.leaflet-container .leaflet-control-connected-peers.disconnected:hover
+{
+    background-color: var(--color-red);
+    color: var(--color-darkGray);
+}
 
 .leaflet-container .leaflet-control-edit-disable:before,
 .leaflet-container .leaflet-control-edit-save:before,

--- a/umap/static/umap/unittests/sync.js
+++ b/umap/static/umap/unittests/sync.js
@@ -8,8 +8,11 @@ import { MapUpdater } from '../js/modules/sync/updaters.js'
 import { SyncEngine, Operations } from '../js/modules/sync/engine.js'
 
 describe('SyncEngine', () => {
+  const websocketTokenURI = 'http://localhost:8000/api/v1/maps/1/websocket_auth_token/'
+  const websocketURI = 'ws://localhost:8000/ws/maps/1/'
+
   it('should initialize methods even before start', () => {
-    const engine = new SyncEngine({})
+    const engine = new SyncEngine({}, websocketTokenURI, websocketURI, {})
     engine.upsert()
     engine.update()
     engine.delete()

--- a/umap/websocket_server.py
+++ b/umap/websocket_server.py
@@ -126,6 +126,10 @@ async def join_and_listen(
 
     try:
         async for raw_message in websocket:
+            if raw_message == "ping":
+                await websocket.send("pong")
+                continue
+
             # recompute the peers list at the time of message-sending.
             # as doing so beforehand would miss new connections
             other_peers = connections.get_other_peers(websocket)

--- a/umap/websocket_server.py
+++ b/umap/websocket_server.py
@@ -196,4 +196,7 @@ def run(host: str, port: int):
             logging.debug(f"Waiting for connections on {host}:{port}")
             await asyncio.Future()  # run forever
 
-    asyncio.run(_serve())
+    try:
+        asyncio.run(_serve())
+    except KeyboardInterrupt:
+        print("Closing WebSocket server")


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/93ed1c60-7e34-410c-94b7-ab85a27e94ae)

(I didn't manage to capture it, but you can see when the next try will happen on hover)

When the websocket is disconnected, try to redo an authentication roundtrip. This commit does the following changes:

- Change the way the SyncEngine is instanciated, passing it a server object and the URLs.
- Add a ping/pong mechanism. This is required because otherwise we have no certainty that the connection is still alive.
- Offer a "reconnect" mechanism, increasing the wait time a bit more each time.
- Trigger the reconnect on disconnections and on failure to connect to the websocket (after a specified time)
- When disconnected the "number of connected peers" now indicates "Disconnected".
- Display a dialog to the users saying that they are disconnected.

Todo:

- [ ] When offline: let the number of connected peers and add disconnected.
- [ ] Changer la couleur de la fenêtre 
- [ ] When offline: change the background color (not red, but something else)
- [ ]  [Here be dragons](https://en.wikipedia.org/wiki/Here_be_dragons). This map has enabled real-time synchronization with other users, but you are currently disconnected. We will try to reconnect in the background and reconcile with other users, but this feature is still experimental, and you might lose data. Have fun!