### PR TITLE
chore: introduce SaveManager class

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -1066,12 +1066,14 @@ export class DataLayer extends ServerStored {
           ),
           async () => {
             // Save again this layer
-            await this._trySave(url, {}, formData)
-            this.isDirty = false
+            const status = await this._trySave(url, {}, formData)
+            if (status) {
+              this.isDirty = false
 
-            // Call the main save, in case something else needs to be saved
-            // as the conflict stopped the saving flow
-            await this.map.saveAll()
+              // Call the main save, in case something else needs to be saved
+              // as the conflict stopped the saving flow
+              await this.map.saveAll()
+            }
           }
         )
       }

--- a/umap/static/umap/js/modules/global.js
+++ b/umap/static/umap/js/modules/global.js
@@ -31,6 +31,7 @@ import { DataLayer, LAYER_TYPES } from './data/layer.js'
 import { DataLayerPermissions, MapPermissions } from './permissions.js'
 import { Point, LineString, Polygon } from './data/features.js'
 import { LeafletMarker, LeafletPolyline, LeafletPolygon } from './rendering/ui.js'
+import { SAVEMANAGER } from './saving.js'
 
 // Import modules and export them to the global scope.
 // For the not yet module-compatible JS out there.
@@ -48,6 +49,7 @@ window.U = {
   DataLayer,
   DataLayerPermissions,
   Dialog,
+  SAVEMANAGER,
   EditPanel,
   Facets,
   Formatter,

--- a/umap/static/umap/js/modules/global.js
+++ b/umap/static/umap/js/modules/global.js
@@ -31,7 +31,7 @@ import { DataLayer, LAYER_TYPES } from './data/layer.js'
 import { DataLayerPermissions, MapPermissions } from './permissions.js'
 import { Point, LineString, Polygon } from './data/features.js'
 import { LeafletMarker, LeafletPolyline, LeafletPolygon } from './rendering/ui.js'
-import { SAVEMANAGER } from './saving.js'
+import * as SAVEMANAGER from './saving.js'
 
 // Import modules and export them to the global scope.
 // For the not yet module-compatible JS out there.
@@ -49,7 +49,6 @@ window.U = {
   DataLayer,
   DataLayerPermissions,
   Dialog,
-  SAVEMANAGER,
   EditPanel,
   Facets,
   Formatter,
@@ -72,6 +71,7 @@ window.U = {
   Request,
   RequestError,
   Rules,
+  SAVEMANAGER,
   SCHEMA,
   ServerRequest,
   Share,

--- a/umap/static/umap/js/modules/permissions.js
+++ b/umap/static/umap/js/modules/permissions.js
@@ -1,24 +1,17 @@
 import { DomUtil } from '../../vendors/leaflet/leaflet-src.esm.js'
 import { translate } from './i18n.js'
 import { uMapAlert as Alert } from '../components/alerts/alert.js'
+import { ServerStored } from './saving.js'
 import * as Utils from './utils.js'
 
 // Dedicated object so we can deal with a separate dirty status, and thus
 // call the endpoint only when needed, saving one call at each save.
-export class MapPermissions {
+export class MapPermissions extends ServerStored {
   constructor(map) {
+    super()
     this.setOptions(map.options.permissions)
     this.map = map
     this._isDirty = false
-  }
-
-  set isDirty(status) {
-    this._isDirty = status
-    if (status) this.map.isDirty = status
-  }
-
-  get isDirty() {
-    return this._isDirty
   }
 
   setOptions(options) {
@@ -200,8 +193,8 @@ export class MapPermissions {
     )
     if (!error) {
       this.commit()
-      this.isDirty = false
       this.map.fire('postsync')
+      return true
     }
   }
 
@@ -233,8 +226,9 @@ export class MapPermissions {
   }
 }
 
-export class DataLayerPermissions {
+export class DataLayerPermissions extends ServerStored {
   constructor(datalayer) {
+    super()
     this.options = Object.assign(
       {
         edit_status: null,
@@ -243,16 +237,6 @@ export class DataLayerPermissions {
     )
 
     this.datalayer = datalayer
-    this._isDirty = false
-  }
-
-  set isDirty(status) {
-    this._isDirty = status
-    if (status) this.datalayer.isDirty = status
-  }
-
-  get isDirty() {
-    return this._isDirty
   }
 
   get map() {
@@ -297,12 +281,13 @@ export class DataLayerPermissions {
     )
     if (!error) {
       this.commit()
-      this.isDirty = false
+      return true
     }
   }
 
   commit() {
     this.datalayer.options.permissions = Object.assign(
+      {},
       this.datalayer.options.permissions,
       this.options
     )

--- a/umap/static/umap/js/modules/saving.js
+++ b/umap/static/umap/js/modules/saving.js
@@ -17,19 +17,19 @@ export class SaveManager {
 
   add(obj) {
     this._queue.add(obj)
-    this.checkStatus()
+    this.updateDOM()
   }
 
   delete(obj) {
     this._queue.delete(obj)
-    this.checkStatus()
+    this.updateDOM()
   }
 
   has(obj) {
     return this._queue.has(obj)
   }
 
-  checkStatus() {
+  updateDOM() {
     document.body.classList.toggle('umap-is-dirty', this._queue.size)
   }
 }

--- a/umap/static/umap/js/modules/saving.js
+++ b/umap/static/umap/js/modules/saving.js
@@ -1,0 +1,54 @@
+export class SaveManager {
+  constructor() {
+    this._queue = new Set()
+  }
+
+  get isDirty() {
+    return Boolean(this._queue.size)
+  }
+
+  async save() {
+    for (const obj of this._queue) {
+      const ok = await obj.save()
+      if (!ok) break
+      this.delete(obj)
+    }
+  }
+
+  add(obj) {
+    this._queue.add(obj)
+    this.checkStatus()
+  }
+
+  delete(obj) {
+    this._queue.delete(obj)
+    this.checkStatus()
+  }
+
+  has(obj) {
+    return this._queue.has(obj)
+  }
+
+  checkStatus() {
+    document.body.classList.toggle('umap-is-dirty', this._queue.size)
+  }
+}
+
+export const SAVEMANAGER = new SaveManager()
+
+export class ServerStored {
+  set isDirty(status) {
+    if (status) {
+      SAVEMANAGER.add(this)
+    } else {
+      SAVEMANAGER.delete(this)
+    }
+    this.onDirty(status)
+  }
+
+  get isDirty() {
+    return SAVEMANAGER.has(this)
+  }
+
+  onDirty(status) {}
+}

--- a/umap/static/umap/js/modules/saving.js
+++ b/umap/static/umap/js/modules/saving.js
@@ -1,53 +1,47 @@
-export class SaveManager {
-  constructor() {
-    this._queue = new Set()
-  }
+const _queue = new Set()
 
-  get isDirty() {
-    return Boolean(this._queue.size)
-  }
+export let isDirty = false
 
-  async save() {
-    for (const obj of this._queue) {
-      const ok = await obj.save()
-      if (!ok) break
-      this.delete(obj)
-    }
-  }
-
-  add(obj) {
-    this._queue.add(obj)
-    this.updateDOM()
-  }
-
-  delete(obj) {
-    this._queue.delete(obj)
-    this.updateDOM()
-  }
-
-  has(obj) {
-    return this._queue.has(obj)
-  }
-
-  updateDOM() {
-    document.body.classList.toggle('umap-is-dirty', this._queue.size)
+export async function save() {
+  for (const obj of _queue) {
+    const ok = await obj.save()
+    if (!ok) break
+    remove(obj)
   }
 }
 
-export const SAVEMANAGER = new SaveManager()
+export function add(obj) {
+  _queue.add(obj)
+  _onUpdate()
+}
+
+export function remove(obj) {
+  _queue.delete(obj)
+  _onUpdate()
+}
+
+export function has(obj) {
+  return _queue.has(obj)
+}
+
+function _onUpdate() {
+  console.log(_queue)
+  isDirty = Boolean(_queue.size)
+  document.body.classList.toggle('umap-is-dirty', isDirty)
+}
 
 export class ServerStored {
   set isDirty(status) {
     if (status) {
-      SAVEMANAGER.add(this)
+      add(this)
     } else {
-      SAVEMANAGER.delete(this)
+      remove(this)
     }
     this.onDirty(status)
   }
 
   get isDirty() {
-    return SAVEMANAGER.has(this)
+    return has(this)
   }
 
   onDirty(status) {}

--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -734,7 +734,7 @@ const ControlsMixin = {
       'leaflet-control-edit-save button',
       rightContainer,
       L.DomUtil.add('span', '', null, L._('Save')),
-      this.save,
+      this.saveAll,
       this
     )
     L.DomEvent.on(

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -153,13 +153,13 @@ U.Map = L.Map.extend({
       this.options.onLoadPanel = 'datafilters'
     }
 
-    let isDirty = false // self status
+    // TODO: remove me when moved to modules
+    // and inheriting from ServerStored
     try {
       Object.defineProperty(this, 'isDirty', {
-        get: () => isDirty,
+        get: () => U.SAVEMANAGER.has(this),
         set: function (status) {
-          isDirty = status
-          this.checkDirty()
+          U.SAVEMANAGER.add(this)
         },
       })
     } catch (e) {
@@ -200,7 +200,7 @@ U.Map = L.Map.extend({
       this.propagate()
     }
 
-    window.onbeforeunload = () => (this.editEnabled && this.isDirty) || null
+    window.onbeforeunload = () => (this.editEnabled && U.SAVEMANAGER.isDirty) || null
     this.backup()
   },
 
@@ -601,13 +601,13 @@ U.Map = L.Map.extend({
       let used = true
       switch (e.key) {
         case 'e':
-          if (!this.isDirty) this.disableEdit()
+          if (!U.SAVEMANAGER.isDirty) this.disableEdit()
           break
         case 's':
-          if (this.isDirty) this.save()
+          if (U.SAVEMANAGER.isDirty) this.saveAll()
           break
         case 'z':
-          if (this.isDirty) this.askForReset()
+          if (U.SAVEMANAGER.isDirty) this.askForReset()
           break
         case 'm':
           this.editTools.startMarker()
@@ -1015,10 +1015,6 @@ U.Map = L.Map.extend({
     this.onDataLayersChanged()
   },
 
-  checkDirty: function () {
-    this._container.classList.toggle('umap-is-dirty', this.isDirty)
-  },
-
   exportOptions: function () {
     const properties = {}
     for (const option of Object.keys(U.SCHEMA)) {
@@ -1029,7 +1025,7 @@ U.Map = L.Map.extend({
     return properties
   },
 
-  saveSelf: async function () {
+  save: async function () {
     this.rules.commit()
     const geojson = {
       type: 'Feature',
@@ -1048,7 +1044,7 @@ U.Map = L.Map.extend({
       return
     }
     if (data.login_required) {
-      window.onLogin = () => this.save()
+      window.onLogin = () => this.saveAll()
       window.open(data.login_required)
       return
     }
@@ -1093,21 +1089,11 @@ U.Map = L.Map.extend({
     return true
   },
 
-  save: async function () {
-    if (!this.isDirty) return
+  saveAll: async function () {
+    if (!U.SAVEMANAGER.isDirty) return
     if (this._default_extent) this._setCenterAndZoom()
     this.backup()
-    if (this.options.editMode === 'advanced') {
-      // Only save the map if the user has the rights to do so.
-      const ok = await this.saveSelf()
-      if (!ok) return
-    }
-    await this.permissions.save()
-    // Iter over all datalayers, including deleted.
-    for (const datalayer of Object.values(this.datalayers)) {
-      if (datalayer.isDirty) await datalayer.save()
-    }
-    this.isDirty = false
+    await U.SAVEMANAGER.save()
     // Do a blind render for now, as we are not sure what could
     // have changed, we'll be more subtil when we'll remove the
     // save action

--- a/umap/static/umap/js/umap.js
+++ b/umap/static/umap/js/umap.js
@@ -158,8 +158,12 @@ U.Map = L.Map.extend({
     try {
       Object.defineProperty(this, 'isDirty', {
         get: () => U.SAVEMANAGER.has(this),
-        set: function (status) {
-          U.SAVEMANAGER.add(this)
+        set: (status) => {
+          if (status) {
+            U.SAVEMANAGER.add(this)
+          } else {
+            U.SAVEMANAGER.remove(this)
+          }
         },
       })
     } catch (e) {

--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -596,7 +596,7 @@ ul.photon-autocomplete {
 }
 .umap-edit-enabled .leaflet-control-edit-save,
 .umap-edit-enabled .leaflet-control-edit-disable,
-.umap-edit-enabled .umap-is-dirty .leaflet-control-edit-cancel {
+.umap-edit-enabled.umap-is-dirty .leaflet-control-edit-cancel {
     display: inline-block;
 }
 .umap-is-dirty .leaflet-control-edit-disable {

--- a/umap/tests/integration/test_edit_datalayer.py
+++ b/umap/tests/integration/test_edit_datalayer.py
@@ -120,7 +120,7 @@ def test_can_change_name(live_server, openmap, page, datalayer):
     page.locator('input[name="name"]').press("Control+a")
     page.locator('input[name="name"]').fill("new name")
     expect(page.locator(".umap-browser .datalayer")).to_contain_text("new name")
-    expect(page.locator(".umap-is-dirty")).to_be_visible()
+    expect(page.locator("body")).to_have_class(re.compile(".*umap-is-dirty.*"))
     with page.expect_response(re.compile(".*/datalayer/update/.*")):
         page.get_by_role("button", name="Save").click()
     saved = DataLayer.objects.last()

--- a/umap/tests/integration/test_save.py
+++ b/umap/tests/integration/test_save.py
@@ -1,0 +1,35 @@
+import re
+
+
+def test_reseting_map_would_remove_from_save_queue(
+    live_server, openmap, page, datalayer
+):
+    page.goto(f"{live_server.url}{openmap.get_absolute_url()}?edit")
+    page.get_by_role("link", name="Edit map name and caption").click()
+    requests = []
+
+    def register_request(request):
+        if request.url.endswith(".png"):
+            return
+        requests.append((request.method, request.url))
+
+    page.on("request", register_request)
+    page.locator('input[name="name"]').click()
+    page.locator('input[name="name"]').fill("new name")
+    page.get_by_role("button", name="Cancel edits").click()
+    page.get_by_role("button", name="OK").click()
+    page.wait_for_timeout(500)
+    page.get_by_role("button", name="Edit").click()
+    page.get_by_role("link", name="Manage layers").click()
+    page.get_by_role("button", name="Edit", exact=True).click()
+    page.locator('input[name="name"]').click()
+    page.locator('input[name="name"]').fill("new datalayer name")
+    with page.expect_response(re.compile(".*/datalayer/update/.*")):
+        page.get_by_role("button", name="Save").click()
+    assert len(requests) == 1
+    assert requests == [
+        (
+            "POST",
+            f"{live_server.url}/en/map/{openmap.pk}/datalayer/update/{datalayer.pk}/",
+        ),
+    ]


### PR DESCRIPTION
The last refactor of the save process (0fdb70ce669838f9fd66eb5de570ffde78e3653d) has introduced a bug: the save flow was not more stopped when a layer fail to save. This ends with a broken UI, as the map is not dirty anymore, so the save button is not active anymore, while at least one layer still needs to be saved.

Save can fail in two scenarios:
  - there is a conflict (status 412)
  - the server is down or as an issue (eg. disk is full)

I tried a more modest scenario (listening for status in map.save and recallign the map save after a conflict), but this ended with calling map.save uselessly even more.

So I decided to try this refactor, which also totally remove the useless map.save we were sending at each save until now.