### PR TITLE
fix: honour `rules` and `slideshow` when importing a umap file

### DIFF
--- a/umap/static/umap/js/modules/rules.js
+++ b/umap/static/umap/js/modules/rules.js
@@ -196,10 +196,10 @@ export default class Rules {
   constructor(umap) {
     this._umap = umap
     this.rules = []
-    this.loadRules()
+    this.load()
   }
 
-  loadRules() {
+  load() {
     if (!this._umap.properties.rules?.length) return
     for (const { condition, options } of this._umap.properties.rules) {
       if (!condition) continue

--- a/umap/static/umap/js/modules/slideshow.js
+++ b/umap/static/umap/js/modules/slideshow.js
@@ -18,7 +18,7 @@ export default class Slideshow extends WithTemplate {
     this._umap = umap
     this._id = null
     this.CLASSNAME = 'umap-slideshow-active'
-    this.setProperties(properties)
+    this.load()
     this._current = null
 
     if (this.properties.autoplay) {
@@ -54,7 +54,11 @@ export default class Slideshow extends WithTemplate {
     return this.current.getNext()
   }
 
-  setProperties(properties) {
+  load() {
+    this.setProperties(this._umap.properties.slideshow)
+  }
+
+  setProperties(properties = {}) {
     this.properties = Object.assign(
       {
         delay: 5000,


### PR DESCRIPTION
Side note (for another PR I'd say): this usually occurs on a non saved map, but in case the map already exist and is in sync mode, should we sync each property (safer but one call per property) or the whole properties object (lighter, but may override unwanted things in remote, and currently there is no method to do so).