### PR TITLE
fix: honour custom labelKey in default popup template

### DIFF
--- a/umap/static/umap/js/modules/rendering/template.js
+++ b/umap/static/umap/js/modules/rendering/template.js
@@ -35,6 +35,7 @@ class PopupTemplate {
       feature.properties.description || '',
       properties
     )
+    properties.name = properties.name ?? feature.getDisplayName()
     let content = Utils.greedyTemplate(template, properties)
     content = Utils.toHTML(content, { target: target })
     return Utils.loadTemplate(`<div class="umap-popup-container text">${content}</div>`)

--- a/umap/tests/integration/test_view_marker.py
+++ b/umap/tests/integration/test_view_marker.py
@@ -57,6 +57,18 @@ def test_should_handle_locale_var_in_description(live_server, map, page):
     expect(link).to_have_attribute("href", "https://domain.org/?locale=en")
 
 
+def test_should_use_custom_label_key_in_popup_default_template(live_server, map, page):
+    data = deepcopy(DATALAYER_DATA)
+    data["features"][0]["properties"] = {
+        "libellé": "my custom label",
+    }
+    data["_umap_options"] = {"labelKey": "libellé"}
+    DataLayerFactory(map=map, data=data)
+    page.goto(f"{live_server.url}{map.get_absolute_url()}")
+    page.locator(".leaflet-marker-icon").click()
+    expect(page.locator(".umap-popup h4")).to_have_text("my custom label")
+
+
 def test_should_display_tooltip_with_variable(live_server, map, page, bootstrap):
     map.settings["properties"]["showLabel"] = True
     map.settings["properties"]["labelKey"] = "Foo {name}"


### PR DESCRIPTION
The default popup template expects a `name` key, so let's populate it.