### PR TITLE
chore: update browserslist to be more explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "simple-statistics": "7.8.5"
   },
   "browserslist": [
-    "> 0.5%, last 2 versions, Firefox ESR, not dead, not op_mini all"
+    "defaults and fully supports es6-module"
   ]
 }


### PR DESCRIPTION
Given that we need to support ES6 modules, better to write it down explicitely.

Current audience coverage is unchanged: 88.3 %

See https://browsersl.ist/#q=%22browserslist%22%3A+%5B%0A++%22defaults+and+fully+supports+es6-module%22%0A%5D vs. https://browsersl.ist/#q=%22browserslist%22%3A+%5B%0A++%22%3E+0.5%25%2C+last+2+versions%2C+Firefox+ESR%2C+not+dead%2C+not+op_mini+all%22%0A%5D