### PR TITLE
fix: allow spaces in iframe query strings in HTML formatting

### DIFF
--- a/umap/static/umap/js/modules/utils.js
+++ b/umap/static/umap/js/modules/utils.js
@@ -174,15 +174,15 @@ export function toHTML(r, options) {
 
   // iframe
   r = r.replace(
-    /{{{(h_t_t_ps?[^ |{]*)}}}/g,
+    /{{{(h_t_t_ps?[^|{]*)}}}/g,
     '<div><iframe frameborder="0" src="$1" width="100%" height="300px"></iframe></div>'
   )
   r = r.replace(
-    /{{{(h_t_t_ps?[^ |{]*)\|(\d*)(px)?}}}/g,
+    /{{{(h_t_t_ps?[^|{]*)\|(\d*)(px)?}}}/g,
     '<div><iframe frameborder="0" src="$1" width="100%" height="$2px"></iframe></div>'
   )
   r = r.replace(
-    /{{{(h_t_t_ps?[^ |{]*)\|(\d*)(px)?\*(\d*)(px)?}}}/g,
+    /{{{(h_t_t_ps?[^|{]*)\|(\d*)(px)?\*(\d*)(px)?}}}/g,
     '<div><iframe frameborder="0" src="$1" width="$4px" height="$2px"></iframe></div>'
   )
 

--- a/umap/static/umap/unittests/utils.js
+++ b/umap/static/umap/unittests/utils.js
@@ -147,12 +147,21 @@ describe('Utils', () => {
       )
     })
 
-    it('should handle iframe with height with px', () => {
+    it('should handle double iframe', () => {
       assert.equal(
         Utils.toHTML(
           'A double iframe: {{{https://osm.org/pouet}}}{{{https://osm.org/boudin}}}'
         ),
         'A double iframe: <div><iframe height="300px" width="100%" src="https://osm.org/pouet" frameborder="0"></iframe></div><div><iframe height="300px" width="100%" src="https://osm.org/boudin" frameborder="0"></iframe></div>'
+      )
+    })
+
+    it('should handle iframe with query string and space', () => {
+      assert.equal(
+        Utils.toHTML(
+          'An iframe with query string: {{{https://osm.org/pouet.html?name=foobar&description=baz baz}}}'
+        ),
+        'An iframe with query string: <div><iframe height="300px" width="100%" src="https://osm.org/pouet.html?name=foobar&amp;description=baz baz" frameborder="0"></iframe></div>'
       )
     })
 
@@ -260,6 +269,19 @@ describe('Utils', () => {
           'http://iframeurl.com': 'value',
         }),
         'A phrase with a {{{http://iframeurl.com}}}.'
+      )
+    })
+
+    it('should process variables in http links', () => {
+      assert.equal(
+        Utils.greedyTemplate(
+          'A phrase with a {{{https://osm.org/pouet?name={name}&description={description}}}}.',
+          {
+            name: 'foobar',
+            description: 'bazbaz',
+          }
+        ),
+        'A phrase with a {{{https://osm.org/pouet?name=foobar&description=bazbaz}}}.'
       )
     })
 


### PR DESCRIPTION
fix #2269