### PR TITLE
fix: do not fail when navigating with popup arrows in cluster mode

### DIFF
--- a/umap/static/umap/js/modules/rendering/popup.js
+++ b/umap/static/umap/js/modules/rendering/popup.js
@@ -44,7 +44,8 @@ const Popup = BasePopup.extend({
     DomEvent.on(el, 'load', () => {
       this._updateLayout()
       this._updatePosition()
-      this._adjustPan()
+      // Do not call when feature is in cluster.
+      if (this._map) this._adjustPan()
     })
   },
 })

--- a/umap/static/umap/js/modules/rendering/template.js
+++ b/umap/static/umap/js/modules/rendering/template.js
@@ -60,7 +60,7 @@ class PopupTemplate {
           feature: nextFeature.properties.name || translate('next'),
         })
         DomEvent.on(next, 'click', () => {
-          nextFeature.zoomTo({ callback: nextFeature.view })
+          nextFeature.zoomTo({ callback: (event) => nextFeature.view(event) })
         })
       }
       if (previousFeature) {
@@ -68,7 +68,7 @@ class PopupTemplate {
           feature: previousFeature.properties.name || translate('previous'),
         })
         DomEvent.on(previous, 'click', () => {
-          previousFeature.zoomTo({ callback: previousFeature.view })
+          previousFeature.zoomTo({ callback: (event) => previousFeature.view(event) })
         })
       }
       DomEvent.on(zoom, 'click', () => feature.zoomTo())


### PR DESCRIPTION
- make sure we have correct `this` in callback
- do not call anymatePan if icon is not added to map (because clusterized)