### PR TITLE
feat: make expression persistent in the overpass importer

### DIFF
--- a/umap/static/umap/js/modules/importers/overpass.js
+++ b/umap/static/umap/js/modules/importers/overpass.js
@@ -53,11 +53,15 @@ export class Importer {
       'https://photon.komoot.io/api?q={q}&layer=county&layer=city&layer=state'
     this.id = 'overpass'
     this.boundaryChoice = null
+    this.expression = null
   }
 
   async open(importer) {
     const container = DomUtil.create('div')
     container.innerHTML = TEMPLATE
+    if (this.expression) {
+      container.querySelector('[name=tags]').value = this.expression
+    }
     this.autocomplete = new Autocomplete(container.querySelector('#area'), {
       url: this.searchUrl,
       placeholder: translate(
@@ -80,6 +84,7 @@ export class Importer {
         Alert.error(translate('Expression is empty'))
         return
       }
+      this.expression = form.tags
       let tags = form.tags
       if (!tags.startsWith('[')) tags = `[${tags}]`
       let area = '{south},{west},{north},{east}'


### PR DESCRIPTION
In other words: fill in the "tags" input with the latest typed expression.

Otherwise, when making tries with overpass imports, one have to type it again and again (it's available through the autocomplete, though, but it's not obvious and it's less friendly IMHO).