### PR TITLE
fixup: make sure to redraw tile after a .umap import

### DIFF
--- a/umap/static/umap/js/modules/sync/updaters.js
+++ b/umap/static/umap/js/modules/sync/updaters.js
@@ -55,7 +55,6 @@ export class DataLayerUpdater extends BaseUpdater {
   upsert({ value }) {
     // Upsert only happens when a new datalayer is created.
     this._umap.createDataLayer(value, false)
-    this._umap.render([])
   }
 
   update({ key, metadata, value }) {

--- a/umap/static/umap/js/modules/umap.js
+++ b/umap/static/umap/js/modules/umap.js
@@ -1554,7 +1554,8 @@ export default class Umap extends ServerStored {
       dataLayer.fromUmapGeoJSON(geojson)
     }
 
-    this._leafletMap.renderUI()
+    // Do a whole render
+    this.render(['name', 'tilelayer', 'limitBounds'])
     this.eachDataLayer((datalayer) => {
       if (mustReindex) datalayer.reindex()
       datalayer.redraw()

--- a/umap/tests/base.py
+++ b/umap/tests/base.py
@@ -42,7 +42,7 @@ class LicenceFactory(factory.django.DjangoModelFactory):
 
 class TileLayerFactory(factory.django.DjangoModelFactory):
     name = "Test zoom layer"
-    url_template = "https://{s}.test.org/osmfr/{z}/{x}/{y}.png"
+    url_template = "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
     attribution = "Test layer attribution"
 
     class Meta:
@@ -156,5 +156,6 @@ def login_required(response):
 
 
 def mock_tiles(route):
+    print("Intercepted route", route.request.url)
     path = Path(__file__).parent / "fixtures/empty_tile.png"
     route.fulfill(path=path)

--- a/umap/tests/integration/conftest.py
+++ b/umap/tests/integration/conftest.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -25,7 +26,7 @@ def set_timeout(context):
 @pytest.fixture(autouse=True)
 def mock_osm_tiles(page):
     if not bool(os.environ.get("PWDEBUG", False)):
-        page.route("*/**/osmfr/**", mock_tiles)
+        page.route(re.compile(r".*tile\..*"), mock_tiles)
 
 
 @pytest.fixture

--- a/umap/tests/integration/test_import.py
+++ b/umap/tests/integration/test_import.py
@@ -72,8 +72,6 @@ def test_umap_import_from_file(live_server, tilelayer, page):
 
 
 def test_umap_import_from_textarea(live_server, tilelayer, page, settings):
-    page.route("https://tile.openstreetmap.fr/hot/**", mock_tiles)
-
     settings.UMAP_ALLOW_ANONYMOUS = True
     page.goto(f"{live_server.url}/map/new/")
     page.get_by_role("button", name="Open browser").click()


### PR DESCRIPTION
Broken since https://github.com/umap-project/umap/commit/20b2290d0033df9de20dcea51a53c24dc6f8db76

Since started as a simple fix, but:
- I first thought my previous fix of the failing test `test_import_umap_from_textarea` was not a real fix, so I changed a bit the way we mock tiles URL in tests, but at the end the test was failing for good reasons
- since 20b2290d0033df9de20dcea51a53c24dc6f8db76 the reset of tilelayer was not called anymore after importing a umap file, so I first made a quick fix for this
- then I decided to refactor a bit more render and propagate, so `importRaw` would pass the exact imported properties (instead of trying to blindly target with some properties), and to remove a call to `propagate`, which at the end should disappear in favor of `render` with better targeting