### PR TITLE
feat: refactor importer feedback

### DIFF
--- a/umap/static/umap/js/modules/umap.js
+++ b/umap/static/umap/js/modules/umap.js
@@ -316,12 +316,14 @@ export default class Umap extends ServerStored {
         dataUrl = this.renderUrl(dataUrl)
         dataUrl = this.proxyUrl(dataUrl)
         const datalayer = this.createDataLayer()
-        await datalayer.importFromUrl(dataUrl, dataFormat)
+        await datalayer
+          .importFromUrl(dataUrl, dataFormat)
+          .then(() => datalayer.zoomTo())
       }
     } else if (data) {
       data = decodeURIComponent(data)
       const datalayer = this.createDataLayer()
-      await datalayer.importRaw(data, dataFormat)
+      await datalayer.importRaw(data, dataFormat).then(() => datalayer.zoomTo())
     }
   }
 
@@ -1514,7 +1516,7 @@ export default class Umap extends ServerStored {
   processFileToImport(file, layer, type) {
     type = type || Utils.detectFileType(file)
     if (!type) {
-      U.Alert.error(
+      Alert.error(
         translate('Unable to detect format of file {filename}', {
           filename: file.name,
         })


### PR DESCRIPTION
We basically make the all import chain return the results as promise, so the importer can act at the end of the process and:
- zoom only to the imported data (in case the layer already as some)
- display a counter of imported data when import is successfull
- display an alert when nothing has been imported

cf #564