### PR TITLE
fix: teach FormBuilder where to look for default values

### DIFF
--- a/umap/static/umap/js/umap.forms.js
+++ b/umap/static/umap/js/umap.forms.js
@@ -1192,6 +1192,21 @@ U.FormBuilder = L.FormBuilder.extend({
     }
   },
 
+  getter: function (field) {
+    const path = field.split('.')
+    let value = this.obj
+    let sub
+    for (sub of path) {
+      try {
+        value = value[sub]
+      } catch {
+        console.log(field)
+      }
+    }
+    if (value === undefined) values = U.SCHEMA[sub]?.default
+    return value
+  },
+
   finish: (event) => {
     event.helper?.input?.blur()
   },


### PR DESCRIPTION
UMap will look into the schema for default values, but untill now FormBuilder wasn't.
This fix is not the real fix we want, but let's make this last until then.
The real fix is to refactor schema and make obj.properties a Proxy object that will then be consumed by FormBuilder as it is now.