### PR TITLE
fix: display current configured oauth as icon instead of text

### DIFF
--- a/umap/static/umap/content.css
+++ b/umap/static/umap/content.css
@@ -41,6 +41,7 @@ body.login header {
     display: inline-block;
 }
 
+.login-grid span,
 .login-grid a {
     border: 1px solid #e5e5e5;
     padding: 5px;

--- a/umap/templates/auth/user_form.html
+++ b/umap/templates/auth/user_form.html
@@ -28,8 +28,8 @@
         </h3>
         <ul>
           {% for name in providers %}
-            <li>
-              {{ name|title }}
+            <li class="login-grid">
+              <span class="login-{{ name }}" title="{{ name }}"></span>
             </li>
           {% endfor %}
         </ul>


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/b71d78c0-2a11-4d2e-adf5-2f23ccfd6b2e)


After:

![image](https://github.com/user-attachments/assets/35d3494c-275a-42b6-b646-6e025b03d7c5)
