### PR TITLE
fix: bring marker to front on highlight

### DIFF
--- a/umap/static/umap/js/modules/rendering/ui.js
+++ b/umap/static/umap/js/modules/rendering/ui.js
@@ -239,10 +239,12 @@ export const LeafletMarker = Marker.extend({
 
   highlight: function () {
     DomUtil.addClass(this.options.icon.elements.main, 'umap-icon-active')
+    this._bringToFront()
   },
 
   resetHighlight: function () {
     DomUtil.removeClass(this.options.icon.elements.main, 'umap-icon-active')
+    this._resetZIndex()
   },
 
   getPopupToolbarAnchor: function () {

--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -924,7 +924,6 @@ a.umap-control-caption,
     width: 2px;
 }
 .umap-icon-active {
-    z-index: var(--zindex-icon-active)!important;
     opacity: 1.0!important;
 }
 .umap-edit-enabled .readonly {

--- a/umap/static/umap/vars.css
+++ b/umap/static/umap/vars.css
@@ -48,7 +48,6 @@
     --zindex-autocomplete: 470;
     --zindex-dialog: 460;
     --zindex-contextmenu: 455;
-    --zindex-icon-active: 450;
     --zindex-tooltip: 445;
     --zindex-panels: 440;
     --zindex-controls: 430;


### PR DESCRIPTION
fix #2351

The actual zIndex of a marker is computed by Leaflet, not set in CSS.