### PR TITLE
fix: do not try to restore a newly created layer on reset

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -611,7 +611,10 @@ export class DataLayer extends ServerStored {
   }
 
   reset() {
-    if (!this.createdOnServer) this.erase()
+    if (!this.createdOnServer) {
+      this.erase()
+      return
+    }
 
     this.resetOptions()
     this.parentPane.appendChild(this.pane)


### PR DESCRIPTION
When asking for cancel, a layer that has not yet been saved to the server should only be erased, no need to try to restore its previous state.