### PR TITLE
fix(#2391): split zoomTo to accept bounds

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -950,9 +950,13 @@ export class DataLayer extends ServerStored {
     else this.hide()
   }
 
-  zoomTo(bounds) {
+  zoomTo() {
     if (!this.isVisible()) return
-    bounds = bounds || this.layer.getBounds()
+    const bounds = this.layer.getBounds()
+    this.zoomToBounds(bounds)
+  }
+
+  zoomToBounds(bounds) {
     if (bounds.isValid()) {
       const options = { maxZoom: this.getOption('zoomTo') }
       this._leafletMap.fitBounds(bounds, options)

--- a/umap/static/umap/js/modules/importer.js
+++ b/umap/static/umap/js/modules/importer.js
@@ -382,7 +382,7 @@ export default class Importer extends Utils.WithTemplate {
         bounds.extend(featureBounds)
       }
       this.onSuccess(features.length)
-      layer.zoomTo(bounds)
+      layer.zoomToBounds(bounds)
     }
   }
 }


### PR DESCRIPTION
Since https://github.com/umap-project/umap/commit/de921660c9448066dc810c418811f30e2186282e#diff-4a01a166046bdf7e4ea7d41d97cd82a57c82f63d10d1697f76e6fe22bfa769ebR954 we were calling it with bounds but also with the click event sometimes.