### PR TITLE
fix: do not load all datalayers at once

### DIFF
--- a/umap/static/umap/js/modules/umap.js
+++ b/umap/static/umap/js/modules/umap.js
@@ -581,9 +581,13 @@ export default class Umap extends ServerStored {
     this.fire('datalayersloaded')
     const toLoad = []
     for (const datalayer of this.datalayersIndex) {
-      if (datalayer.showAtLoad()) toLoad.push(datalayer.show())
+      if (datalayer.showAtLoad()) toLoad.push(() => datalayer.show())
     }
-    await Promise.all(toLoad)
+    while (toLoad.length) {
+      const chunk = toLoad.splice(0, 10)
+      await Promise.all(chunk.map((func) => func()))
+    }
+
     this.dataloaded = true
     this.fire('dataloaded')
   }


### PR DESCRIPTION
Some maps have dozens, even hundreds of layers