### PR TITLE
fix(helm): reference secret-env by fullname instead release-name

### DIFF
--- a/charts/umap/templates/deployment.yaml
+++ b/charts/umap/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
       volumes:
         - name: config
           secret:
-            secretName: {{ .Release.Name }}-config
+            secretName: {{ include "umap.fullname" . }}-config
         - name: statics
           emptyDir: {}
       {{- if .Values.persistence.enabled }}

--- a/charts/umap/templates/deployment.yaml
+++ b/charts/umap/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
           {{- end }}
           envFrom:
           - secretRef:
-              name: {{ .Release.Name }}-env
+              name: {{ include "umap.fullname" . }}-env
           volumeMounts:
             - name: config
               mountPath: /etc/umap/


### PR DESCRIPTION
Related to helm Charts:
Currently the reference to secret is done by
```          
envFrom:
- secretRef:
  name: {{ .Release.Name }}-env
```
[Link](https://github.com/umap-project/umap/blob/master/charts/umap/templates/deployment.yaml#L67C1-L69C44)

but secret object is created like this:
```
metadata:
  name: {{ include "umap.fullname" . }}-env
```
[Link](https://github.com/umap-project/umap/blob/master/charts/umap/templates/secret-env.yaml#L4C3-L4C4)

Works as long as no Sub-Chart feature is used, when individual configuration is stored within a git repo.
Then the subchart name is added to fullname. (And I think if custom fullName is set)

To be safe, `{{ include "umap.fullname" . }}` is correct. 

Should be no breaking change, when it is working at the moment. (Because then both return same value)
It is only a breaking change, if it is not working at the moment.

