### PR TITLE
feat(helm): custom template support with helm charts

### DIFF
--- a/charts/umap/templates/configmap-templates.yaml
+++ b/charts/umap/templates/configmap-templates.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.umap.templates}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "umap.fullname" . }}-templates
+  labels:
+    {{- include "umap.labels" . | nindent 4 }}
+data:
+{{- range $k, $v := .Values.umap.templates }}
+    {{ $k }}: {{ $v | quote }}
+{{- end }}
+{{end}}

--- a/charts/umap/templates/deployment.yaml
+++ b/charts/umap/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/secret-config.yaml") . | sha256sum }}
+        checksum/templates: {{ include (print $.Template.BasePath "/configmap-templates.yaml") . | sha256sum }}
         checksum/env: {{ include (print $.Template.BasePath "/secret-env.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
@@ -77,6 +78,14 @@ spec:
             - name: data
               mountPath: /srv/umap/uploads/
           {{- end }}
+          {{- if .Values.umap.templates}}
+          {{- range $k, $v := .Values.umap.templates }}
+            - name: templates
+              mountPath: /venv/lib/python3.11/site-packages/umap/templates/umap/{{- $k }}
+              subPath: {{ $k }}
+          {{- end }}
+          {{- end }}
+
       volumes:
         - name: config
           secret:
@@ -88,6 +97,12 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "umap.pvcName" . }}
       {{- end }}
+      {{- if .Values.umap.templates}}
+        - name: templates
+          configMap:
+            name: {{ include "umap.fullname" . }}-templates        
+      {{- end }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/umap/values.yaml
+++ b/charts/umap/values.yaml
@@ -77,6 +77,17 @@ umap:
     SECRET_KEY: CHANGE_ME
     STATIC_ROOT: /srv/umap/static
     MEDIA_ROOT: /srv/umap/uploads
+  
+  templates: {}
+    # Overwrite templates like footer.html or header.html
+    #  footer.html: |
+    #    <a href="/imprint">Imprint</a>
+    #  header.html: |
+    #    custom Header    
+    #
+    # It is not recommended to overwrite other templates!
+    # list of templates: https://github.com/umap-project/umap/tree/master/umap/templates/umap
+    
   # You can also provide umap.conf content here:
   config: |
     from umap.settings.base import *


### PR DESCRIPTION
Because I don't feel comfortable to host this application without a link called "Imprint", so I added support to provide custom templates also within helm charts. Sometimes this is checked very detailed in Germany. 

The only topic, I'm not fully sure about, is the directory, where they should be stored. Currently I overwrite the templates within */venv/lib/python3.11/site-packages/umap/templates/umap/*
This feels not correct.

I added examples within values.yaml.

Every template can be overwritten within values.yaml like this:
```
  templates:
    footer.html: |
      Custom footer
    
    header.html: |
      Custom Header
    
    content_footer.html: |
        {% load i18n %}

        <footer>
          <a href="https://wiki.openstreetmap.org/wiki/UMap" class="branding">uMap</a>
          <span>{% trans "An OpenStreetMap project" %}
          ({% trans "version" %} <a href="https://docs.umap-project.org/en/stable/changelog/">{{ UMAP_VERSION }}</a>)</span>
          {% if UMAP_HOST_INFOS.url and UMAP_HOST_INFOS.name %}<span>{% trans "Hosted by" %} <a href="{{ UMAP_HOST_INFOS.url }}">{{ UMAP_HOST_INFOS.name }}</a></span>{% endif %}
          {% if UMAP_HOST_INFOS.email %}<a href="mailto:{{ UMAP_HOST_INFOS.email }}">{% trans "Contact" %}</a>{% endif %}
          {% if UMAP_HELP_URL %}<a href="{{ UMAP_HELP_URL }}">{% trans "Help" %}</a>{% endif %}
          <a href="https://domain.com/imprint">Imprint</a>
          {% get_language_info_list for LANGUAGES as languages %}
          <form action="{% url "set_language" %}" method="post" class="i18n_switch">
            {% csrf_token %}
            <select name="language" onchange="this.form.submit()">
              {% for language in languages %}
                <option value="{{ language.code }}"
                        {% if language.code == LANGUAGE_CODE %}selected="selected"{% endif %}>
                  {{ language.name_local }} ({{ language.code }})
                </option>
              {% endfor %}
            </select>
          </form>
        </footer>
```

**btw: Great application! Helped me a lot within last weeks. 👍**