### PR TITLE
fix(sync): do not try to reconnect after end edit

### DIFF
--- a/umap/static/umap/js/modules/sync/engine.js
+++ b/umap/static/umap/js/modules/sync/engine.js
@@ -61,6 +61,7 @@ export class SyncEngine {
     this._reconnectTimeout = null
     this._reconnectDelay = RECONNECT_DELAY
     this.websocketConnected = false
+    this.closeRequested = false
   }
 
   async authenticate() {

--- a/umap/static/umap/js/modules/sync/websocket.js
+++ b/umap/static/umap/js/modules/sync/websocket.js
@@ -5,7 +5,6 @@ const FIRST_CONNECTION_TIMEOUT = 2000
 export class WebSocketTransport {
   constructor(webSocketURI, authToken, messagesReceiver) {
     this.receiver = messagesReceiver
-    this.closeRequested = false
 
     this.websocket = new WebSocket(webSocketURI)
 
@@ -16,7 +15,7 @@ export class WebSocketTransport {
     this.websocket.addEventListener('message', this.onMessage.bind(this))
     this.websocket.onclose = () => {
       console.log('websocket closed')
-      if (!this.closeRequested) {
+      if (!this.receiver.closeRequested) {
         console.log('Not requested, reconnecting...')
         this.receiver.reconnect()
       }
@@ -64,7 +63,7 @@ export class WebSocketTransport {
   }
 
   close() {
-    this.closeRequested = true
+    this.receiver.closeRequested = true
     this.websocket.close()
   }
 }


### PR DESCRIPTION
We now set the "closeRequested" on the receiver itself, otherwise there is a race condition between the reconnect (which create a new transport) and the onclose checking closeRequest on an old transport.