### PR TITLE
fix(sync): deactivate cancel and hide button when sync is active

### DIFF
--- a/umap/static/umap/js/modules/ui/bar.js
+++ b/umap/static/umap/js/modules/ui/bar.js
@@ -145,7 +145,9 @@ export class TopBar extends WithTemplate {
   }
 
   redraw() {
-    this.elements.peers.hidden = !this._umap.getProperty('syncEnabled')
+    const syncEnabled = this._umap.getProperty('syncEnabled')
+    this.elements.peers.hidden = !syncEnabled
+    this.elements.cancel.hidden = syncEnabled
     this.elements.saveLabel.hidden = this._umap.permissions.isDraft()
     this.elements.saveDraftLabel.hidden = !this._umap.permissions.isDraft()
   }

--- a/umap/static/umap/js/modules/umap.js
+++ b/umap/static/umap/js/modules/umap.js
@@ -1259,6 +1259,7 @@ export default class Umap extends ServerStored {
   }
 
   askForReset(e) {
+    if (this.getProperty('syncEnabled')) return
     this.dialog
       .confirm(translate('Are you sure you want to cancel your changes?'))
       .then(() => {


### PR DESCRIPTION
fix #2265

Let's reactivate when we have a proper undo-redo (cf #1107)