### PR TITLE
fix: keep layer visibility after clicking on toggle all

### DIFF
--- a/umap/static/umap/js/modules/browser.js
+++ b/umap/static/umap/js/modules/browser.js
@@ -254,6 +254,7 @@ export default class Browser {
       if (datalayer.isVisible()) allHidden = false
     })
     this._umap.eachBrowsableDataLayer((datalayer) => {
+      datalayer._forcedVisibility = true
       if (allHidden) {
         datalayer.show()
       } else {


### PR DESCRIPTION
fix #2430

Not exactly sure how to make this DRY. What we want is to mark the layer visibility as "controlled by user" as soon as they click on a show/hide/showAll/hideAll button, so we do not try to infer the visibility from the from/toZoom settings.