### PR TITLE
a11y: include site description within page titles

### DIFF
--- a/docs/config/settings.md
+++ b/docs/config/settings.md
@@ -98,7 +98,12 @@ Eg.: `SHORT_SITE_URL=https://u.umap.org`
 
 #### SITE_NAME
 
-The name of the site, to be used in header and HTML title.
+The name of the site, to be used in header.
+
+
+#### SITE_DESCRIPTION
+
+The description of the site, to be used in HTML title.
 
 
 #### SITE_URL

--- a/umap/context_processors.py
+++ b/umap/context_processors.py
@@ -7,6 +7,7 @@ def settings(request):
     return {
         "UMAP_HELP_URL": djsettings.UMAP_HELP_URL,
         "SITE_NAME": djsettings.SITE_NAME,
+        "SITE_DESCRIPTION": djsettings.SITE_DESCRIPTION,
         "SITE_URL": djsettings.SITE_URL,
         "ENABLE_ACCOUNT_LOGIN": djsettings.ENABLE_ACCOUNT_LOGIN,
         "UMAP_READONLY": djsettings.UMAP_READONLY,

--- a/umap/settings/base.py
+++ b/umap/settings/base.py
@@ -267,6 +267,7 @@ UMAP_KEEP_VERSIONS = env.int("UMAP_KEEP_VERSIONS", default=10)
 SITE_URL = env("SITE_URL", default="http://umap.org")
 SHORT_SITE_URL = env("SHORT_SITE_URL", default=None)
 SITE_NAME = "uMap"
+SITE_DESCRIPTION = "Online map creator"
 UMAP_DEMO_SITE = env("UMAP_DEMO_SITE", default=False)
 UMAP_EXCLUDE_DEFAULT_MAPS = False
 UMAP_MAPS_PER_PAGE = 5

--- a/umap/templates/auth/user_detail.html
+++ b/umap/templates/auth/user_detail.html
@@ -2,6 +2,10 @@
 
 {% load i18n %}
 
+{% block head_title %}
+  {% blocktranslate %}{{ current_user }}’s maps{% endblocktranslate %} - {{ SITE_DESCRIPTION }}
+{% endblock head_title %}
+
 {% block maincontent %}
   <div class="col wide">
     <h2 class="section">

--- a/umap/templates/auth/user_form.html
+++ b/umap/templates/auth/user_form.html
@@ -2,6 +2,9 @@
 
 {% load i18n %}
 
+{% block head_title %}
+  {% translate "My Profile" %} - {{ SITE_DESCRIPTION }}
+{% endblock head_title %}
 {% block maincontent %}
   {% include "umap/dashboard_menu.html" with selected="profile" %}
   <div class="wrapper">

--- a/umap/templates/auth/user_stars.html
+++ b/umap/templates/auth/user_stars.html
@@ -2,6 +2,10 @@
 
 {% load i18n %}
 
+{% block head_title %}
+  {% blocktranslate %}{{ current_user }}’s starred maps{% endblocktranslate %} - {{ SITE_DESCRIPTION }}
+{% endblock head_title %}
+
 {% block maincontent %}
   <div class="col wide">
     <h2 class="section">

--- a/umap/templates/base.html
+++ b/umap/templates/base.html
@@ -5,7 +5,7 @@
   <head>
     <title>
       {% block head_title %}
-        {{ SITE_NAME }}
+        {{ SITE_NAME }} - {{ SITE_DESCRIPTION }}
       {% endblock head_title %}
     </title>
     <meta charset="utf-8">

--- a/umap/templates/registration/login.html
+++ b/umap/templates/registration/login.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block head_title %}
-  {% trans "Login" %}
+  {% trans "Login" %} - {{ SITE_DESCRIPTION }}
 {% endblock head_title %}
 {% load umap_tags i18n %}
 

--- a/umap/templates/umap/about.html
+++ b/umap/templates/umap/about.html
@@ -1,4 +1,9 @@
 {% extends "umap/content.html" %}
+{% load i18n %}
+
+{% block head_title %}
+  {% translate "About" %} - {{ SITE_DESCRIPTION }}
+{% endblock head_title %}
 
 {% block maincontent %}
   {% include "umap/about_summary.html" %}

--- a/umap/templates/umap/map_detail.html
+++ b/umap/templates/umap/map_detail.html
@@ -3,7 +3,7 @@
 {% load umap_tags i18n %}
 
 {% block head_title %}
-  {{ map.name }} - {{ SITE_NAME }}
+  {{ map.name }} - {{ SITE_NAME }} - {{ SITE_DESCRIPTION }}
 {% endblock head_title %}
 {% block body_class %}
   map_detail

--- a/umap/templates/umap/password_change.html
+++ b/umap/templates/umap/password_change.html
@@ -2,6 +2,10 @@
 
 {% load i18n %}
 
+{% block head_title %}
+  {% translate "Password change" %} - {{ SITE_DESCRIPTION }}
+{% endblock head_title %}
+
 {% block content %}
   <h2 class="section">
     {% trans "Password change" %}

--- a/umap/templates/umap/password_change_done.html
+++ b/umap/templates/umap/password_change_done.html
@@ -2,6 +2,10 @@
 
 {% load i18n %}
 
+{% block head_title %}
+  {% translate "Password change successful" %} - {{ SITE_DESCRIPTION }}
+{% endblock head_title %}
+
 {% block content %}
   <h2 class="section">
     {% trans "Password change successful" %}

--- a/umap/templates/umap/search.html
+++ b/umap/templates/umap/search.html
@@ -2,6 +2,10 @@
 
 {% load i18n %}
 
+{% block head_title %}
+  {% translate "Explore maps" %} - {{ SITE_DESCRIPTION }}
+{% endblock head_title %}
+
 {% block messages %}
   {# We don't want maps from the results list to display errors in the main page. #}
 {% endblock messages %}

--- a/umap/templates/umap/team_confirm_delete.html
+++ b/umap/templates/umap/team_confirm_delete.html
@@ -2,6 +2,10 @@
 
 {% load i18n %}
 
+{% block head_title %}
+  {% translate "Team deletion" %} - {{ SITE_DESCRIPTION }}
+{% endblock head_title %}
+
 {% block maincontent %}
   {% include "umap/dashboard_menu.html" with selected="teams" %}
   <div class="wrapper">

--- a/umap/templates/umap/team_detail.html
+++ b/umap/templates/umap/team_detail.html
@@ -2,6 +2,10 @@
 
 {% load i18n %}
 
+{% block head_title %}
+  {% blocktranslate %}{{ current_team }}’s maps{% endblocktranslate %} - {{ SITE_DESCRIPTION }}
+{% endblock head_title %}
+
 {% block maincontent %}
   <div class="wrapper">
       <div class="row">

--- a/umap/templates/umap/team_form.html
+++ b/umap/templates/umap/team_form.html
@@ -2,6 +2,10 @@
 
 {% load i18n %}
 
+{% block head_title %}
+  {% translate "Create or edit a team" %} - {{ SITE_DESCRIPTION }}
+{% endblock head_title %}
+
 {% block maincontent %}
   {% include "umap/dashboard_menu.html" with selected="teams" %}
   <div class="wrapper">

--- a/umap/templates/umap/user_dashboard.html
+++ b/umap/templates/umap/user_dashboard.html
@@ -3,7 +3,7 @@
 {% load i18n static %}
 
 {% block head_title %}
-  {{ SITE_NAME }} - {% trans "My Dashboard" %}
+  {% translate "My Dashboard" %} - {{ SITE_DESCRIPTION }}
 {% endblock head_title %}
 {% block maincontent %}
   {% trans "Search my maps" as placeholder %}

--- a/umap/templates/umap/user_teams.html
+++ b/umap/templates/umap/user_teams.html
@@ -2,6 +2,10 @@
 
 {% load i18n %}
 
+{% block head_title %}
+  {% translate "My Teams" %} - {{ SITE_DESCRIPTION }}
+{% endblock head_title %}
+
 {% block maincontent %}
   {% include "umap/dashboard_menu.html" with selected="teams" %}
   <div class="wrapper">

--- a/umap/tests/integration/test_basics.py
+++ b/umap/tests/integration/test_basics.py
@@ -8,7 +8,7 @@ from umap.models import Map
 
 def test_page_title(page, live_server):
     page.goto(live_server.url)
-    expect(page).to_have_title("uMap")
+    expect(page).to_have_title("uMap - Online map creator")
 
 
 @pytest.mark.parametrize(
@@ -83,7 +83,7 @@ def test_login_from_map_page(live_server, page, tilelayer, settings, user, conte
         page.get_by_role("button", name="Save").click()
     assert Map.objects.count() == 0
     login_page = login_page_info.value
-    expect(login_page).to_have_title("Login")
+    expect(login_page).to_have_title("Login - Online map creator")
     login_page.get_by_placeholder("Username").fill(user.username)
     login_page.get_by_placeholder("Password").fill("123123")
     with page.expect_response(re.compile(r".*/map/create/")):


### PR DESCRIPTION
This is not the same as the short `SITE_NAME` which is displayed as the title of the (home)page for instance.

The plan is to set `SITE_DESCRIPTION` as `uMap OpenStreetMap` for the OSM instance and `uMap agents publics` for the ANCT one.