### PR TITLE
fix: clear previous alert timeout when opening a new alert

### DIFF
--- a/umap/static/umap/js/components/alerts/alert.js
+++ b/umap/static/umap/js/components/alerts/alert.js
@@ -57,8 +57,11 @@ class uMapAlert extends uMapElement {
     this.container.dataset.duration = duration
     this.element.textContent = message
     this.setAttribute('open', 'open')
+    if (this._timeoutId) {
+      clearTimeout(this._timeoutId)
+    }
     if (Number.isFinite(duration)) {
-      setTimeout(() => {
+      this._timeoutId = setTimeout(() => {
         this._hide()
       }, duration)
     }


### PR DESCRIPTION
Otherwise, when an infinite alert replace an alert with a finite duration, this first alert timeout will close the second alert.