### PR TITLE
fix: do not try to backup an undefined geojson

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -282,7 +282,9 @@ export class DataLayer extends ServerStored {
   }
 
   backupData() {
-    this._geojson_bk = Utils.CopyJSON(this._geojson)
+    if (this._geojson) {
+      this._geojson_bk = Utils.CopyJSON(this._geojson)
+    }
   }
 
   reindex() {


### PR DESCRIPTION
This occurs when a remote data returns an invalid geojson.