### PR TITLE
chore: use editable-edited event to sync changes

### DIFF
--- a/umap/static/umap/js/modules/rendering/ui.js
+++ b/umap/static/umap/js/modules/rendering/ui.js
@@ -47,6 +47,7 @@ const FeatureMixin = {
   addInteractions: function () {
     this.on('contextmenu editable:vertex:contextmenu', this.onContextMenu)
     this.on('click', this.onClick)
+    this.on('editable:edited', this.onCommit)
   },
 
   onClick: function (event) {
@@ -120,7 +121,6 @@ const PointMixin = {
       this.feature.edit(event)
       this.feature.pullGeometry()
     })
-    this.on('editable:drawing:commit', this.onCommit)
     if (!this.feature.isReadOnly()) this.on('mouseover', this._enableDragging)
     this.on('mouseout', this._onMouseOut)
   },
@@ -285,7 +285,6 @@ const PathMixin = {
 
   addInteractions: function () {
     FeatureMixin.addInteractions.call(this)
-    this.on('editable:disable', this.onCommit)
     this.on('mouseover', this._onMouseOver)
     this.on('drag editable:drag', this._onDrag)
     this.on('popupopen', this.highlightPath)

--- a/umap/tests/integration/test_websocket_sync.py
+++ b/umap/tests/integration/test_websocket_sync.py
@@ -124,11 +124,11 @@ def test_websocket_connection_can_sync_polygons(context, asgi_live_server, tilel
     map.click(position={"x": 100, "y": 100})
     map.click(position={"x": 100, "y": 100})
 
-    # It is created on peerA, but not yet synced
+    # It is created on peerA, and should be on peerB
     expect(a_polygons).to_have_count(1)
-    expect(b_polygons).to_have_count(0)
+    expect(b_polygons).to_have_count(1)
 
-    # Escaping the edition syncs
+    # Escaping the edition should not duplicate
     peerA.keyboard.press("Escape")
     expect(a_polygons).to_have_count(1)
     expect(b_polygons).to_have_count(1)


### PR DESCRIPTION
This is more unified between markers and paths, and it allows paths to be synced as soon as they have been drawn (instead of when closing the edit panel, which created a race condition when changing its properties that were then synced to other while the feature itself was not).