### PR TITLE
fix: error after deleting a path that was previously moved

### DIFF
--- a/umap/static/umap/js/modules/rendering/ui.js
+++ b/umap/static/umap/js/modules/rendering/ui.js
@@ -267,6 +267,8 @@ const PathMixin = {
   },
 
   makeGeometryEditable: function () {
+    // Feature has been removed since then?
+    if (!this._map) return
     if (this._map._umap.editedFeature !== this.feature) {
       this.disableEdit()
       return


### PR DESCRIPTION
When moving a path, this will put a once time listener on "moveend". If we delete this feature, and move the map, we should not execute the event callback.

A better fix would be to cancel the event listener on delete, but that is much more work given how we deal with Leaflet events right now.