### PR TITLE
chore: sync save state

### DIFF
--- a/umap/static/umap/js/modules/rendering/layers/classified.js
+++ b/umap/static/umap/js/modules/rendering/layers/classified.js
@@ -75,7 +75,7 @@ const ClassifiedMixin = {
   },
 
   renderLegend: function (container) {
-    if (!this.datalayer.hasDataLoaded()) return
+    if (!this.datalayer.isLoaded()) return
     const parent = DomUtil.create('ul', '', container)
     const items = this.getLegendItems()
     for (const [color, label] of items) {

--- a/umap/static/umap/js/modules/saving.js
+++ b/umap/static/umap/js/modules/saving.js
@@ -10,6 +10,11 @@ export async function save() {
   }
 }
 
+export function clear() {
+  _queue.clear()
+  onUpdate()
+}
+
 function add(obj) {
   _queue.add(obj)
   onUpdate()

--- a/umap/static/umap/js/modules/sync/engine.js
+++ b/umap/static/umap/js/modules/sync/engine.js
@@ -127,10 +127,13 @@ export class SyncEngine {
   }
 
   saved() {
-    this.transport.send('SavedMessage', {
-      sender: this.peerId,
-      lastKnownHLC: this._operations.getLastKnownHLC(),
-    })
+    if (this.offline) return
+    if (this.transport) {
+      this.transport.send('SavedMessage', {
+        sender: this.peerId,
+        lastKnownHLC: this._operations.getLastKnownHLC(),
+      })
+    }
   }
 
   _send(inputMessage) {

--- a/umap/static/umap/js/modules/sync/updaters.js
+++ b/umap/static/umap/js/modules/sync/updaters.js
@@ -55,15 +55,11 @@ export class DataLayerUpdater extends BaseUpdater {
   upsert({ value }) {
     // Upsert only happens when a new datalayer is created.
     const datalayer = this._umap.createDataLayer(value, false)
-    // Prevent the layer to get data from the server, as it will get it
-    // from the sync.
-    datalayer._loaded = true
   }
 
   update({ key, metadata, value }) {
     const datalayer = this.getDataLayerFromID(metadata.id)
     if (fieldInSchema(key)) {
-      datalayer._loaded = true
       this.updateObjectValue(datalayer, key, value)
     } else {
       console.debug(

--- a/umap/static/umap/js/modules/sync/updaters.js
+++ b/umap/static/umap/js/modules/sync/updaters.js
@@ -63,6 +63,7 @@ export class DataLayerUpdater extends BaseUpdater {
   update({ key, metadata, value }) {
     const datalayer = this.getDataLayerFromID(metadata.id)
     if (fieldInSchema(key)) {
+      datalayer._loaded = true
       this.updateObjectValue(datalayer, key, value)
     } else {
       console.debug(
@@ -92,7 +93,7 @@ export class FeatureUpdater extends BaseUpdater {
   upsert({ metadata, value }) {
     const { id, layerId } = metadata
     const datalayer = this.getDataLayerFromID(layerId)
-    const feature = this.getFeatureFromMetadata(metadata, value)
+    const feature = this.getFeatureFromMetadata(metadata)
 
     if (feature) {
       feature.geometry = value.geometry
@@ -109,7 +110,7 @@ export class FeatureUpdater extends BaseUpdater {
       return
     }
     if (key === 'geometry') {
-      const feature = this.getFeatureFromMetadata(metadata, value)
+      const feature = this.getFeatureFromMetadata(metadata)
       feature.geometry = value
     } else {
       this.updateObjectValue(feature, key, value)

--- a/umap/static/umap/js/modules/umap.js
+++ b/umap/static/umap/js/modules/umap.js
@@ -684,6 +684,7 @@ export default class Umap extends ServerStored {
         Alert.success(translate('Map has been saved!'))
       })
     }
+    this.sync.saved()
     this.fire('saved')
   }
 

--- a/umap/sync/app.py
+++ b/umap/sync/app.py
@@ -14,6 +14,7 @@ from .payloads import (
     OperationMessage,
     PeerMessage,
     Request,
+    SavedMessage,
 )
 
 
@@ -163,6 +164,10 @@ class Peer:
             match incoming.root:
                 # Broadcast all operation messages to connected peers
                 case OperationMessage():
+                    await self.broadcast(text_data)
+
+                # Broadcast the new map state to connected peers
+                case SavedMessage():
                     await self.broadcast(text_data)
 
                 # Send peer messages to the proper peer

--- a/umap/sync/payloads.py
+++ b/umap/sync/payloads.py
@@ -30,10 +30,17 @@ class PeerMessage(BaseModel):
     message: dict
 
 
+class SavedMessage(BaseModel):
+    kind: Literal["SavedMessage"] = "SavedMessage"
+    lastKnownHLC: str
+
+
 class Request(RootModel):
     """Any message coming from the websocket should be one of these, and will be rejected otherwise."""
 
-    root: Union[PeerMessage, OperationMessage] = Field(discriminator="kind")
+    root: Union[PeerMessage, OperationMessage, SavedMessage] = Field(
+        discriminator="kind"
+    )
 
 
 class JoinResponse(BaseModel):

--- a/umap/tests/integration/test_websocket_sync.py
+++ b/umap/tests/integration/test_websocket_sync.py
@@ -557,3 +557,46 @@ def test_create_and_sync_map(new_page, asgi_live_server, tilelayer, login, user)
     peerA.get_by_role("button", name="Edit").click()
     expect(markersA).to_have_count(2)
     expect(markersB).to_have_count(2)
+
+
+@pytest.mark.xdist_group(name="websockets")
+def test_should_sync_saved_status(new_page, asgi_live_server, tilelayer):
+    map = MapFactory(name="sync", edit_status=Map.ANONYMOUS)
+    map.settings["properties"]["syncEnabled"] = True
+    map.save()
+
+    # Create two tabs
+    peerA = new_page("Page A")
+    peerA.goto(f"{asgi_live_server.url}{map.get_absolute_url()}?edit")
+    peerB = new_page("Page B")
+    peerB.goto(f"{asgi_live_server.url}{map.get_absolute_url()}?edit")
+
+    # Create a new marker from peerA
+    peerA.get_by_title("Draw a marker").click()
+    peerA.locator("#map").click(position={"x": 220, "y": 220})
+
+    # Peer A should be in dirty state
+    expect(peerA.locator("body")).to_have_class(re.compile(".*umap-is-dirty.*"))
+
+    # Peer B should not be in dirty state
+    expect(peerB.locator("body")).not_to_have_class(re.compile(".*umap-is-dirty.*"))
+
+    # Create a new marker from peerB
+    peerB.get_by_title("Draw a marker").click()
+    peerB.locator("#map").click(position={"x": 200, "y": 250})
+
+    # Peer B should be in dirty state
+    expect(peerB.locator("body")).to_have_class(re.compile(".*umap-is-dirty.*"))
+
+    # Peer A should still be in dirty state
+    expect(peerA.locator("body")).to_have_class(re.compile(".*umap-is-dirty.*"))
+
+    # Save layer to the server from peerA
+    with peerA.expect_response(re.compile(".*/datalayer/create/.*")):
+        peerA.get_by_role("button", name="Save").click()
+
+    # Peer B should not be in dirty state
+    expect(peerB.locator("body")).not_to_have_class(re.compile(".*umap-is-dirty.*"))
+
+    # Peer A should not be in dirty state
+    expect(peerA.locator("body")).not_to_have_class(re.compile(".*umap-is-dirty.*"))

--- a/umap/tests/integration/test_websocket_sync.py
+++ b/umap/tests/integration/test_websocket_sync.py
@@ -398,7 +398,9 @@ def test_should_sync_datalayers(new_page, asgi_live_server, tilelayer):
     peerA.locator("#map").click()
 
     # Make sure this new marker is in Layer 2 for peerB
-    expect(peerB.get_by_text("Layer 2")).to_be_visible()
+    # Show features for this layer in the brower.
+    peerB.get_by_role("heading", name="Layer 2").locator(".datalayer-name").click()
+    expect(peerB.locator("li").filter(has_text="Layer 2")).to_be_visible()
     peerB.locator(".panel.left").get_by_role("button", name="Show/hide layer").nth(
         1
     ).click()

--- a/umap/tests/integration/test_websocket_sync.py
+++ b/umap/tests/integration/test_websocket_sync.py
@@ -421,9 +421,11 @@ def test_should_sync_datalayers(new_page, asgi_live_server, tilelayer):
         1
     ).click()
 
-    # Now peerA saves the layer 2 to the server
-    with peerA.expect_response(re.compile(".*/datalayer/update/.*")):
-        peerA.get_by_role("button", name="Save").click()
+    # Peer A should not be in dirty state
+    expect(peerA.locator("body")).not_to_have_class(re.compile(".*umap-is-dirty.*"))
+
+    # Peer A should only have two markers
+    expect(peerA.locator(".leaflet-marker-icon")).to_have_count(2)
 
     assert DataLayer.objects.count() == 2
 


### PR DESCRIPTION
When a peer save the map, other peers in dirty state should not need to save the map anymore.

That implementation uses the lastKnownHLC as a reference, but it changes all dirty states at once. Another impementation could be to have each object sync its dirty state, but in this case we do not have a HLC per object as reference, and it also creates more messages.

ping @almet if you're around and wanna have a fresh look. :)