### PR TITLE
fix(sync): try to reconnect after network error when getting token

### DIFF
--- a/umap/static/umap/js/modules/sync/engine.js
+++ b/umap/static/umap/js/modules/sync/engine.js
@@ -71,9 +71,11 @@ export class SyncEngine {
     })
 
     const [response, _, error] = await this._umap.server.get(websocketTokenURI)
-    if (!error) {
-      this.start(response.token)
+    if (error) {
+      this.reconnect()
+      return
     }
+    this.start(response.token)
   }
 
   start(authToken) {


### PR DESCRIPTION
Otherwise, if the token request fail, the process will be stopped and we will never try to reconnect.