### PR TITLE
fix: do not display an error for an empty CSV

### DIFF
--- a/umap/static/umap/js/modules/formatter.js
+++ b/umap/static/umap/js/modules/formatter.js
@@ -103,8 +103,12 @@ export class Formatter {
               message: err[0].message,
             })
           }
-          Alert.error(message, 10000)
-          console.debug(err)
+          if (str.split(/\r\n|\r|\n/).length <= 2) {
+            // Seems like a blank CSV, let's not warn
+            console.debug(err)
+          } else {
+            Alert.error(message, 10000)
+          }
         }
         if (result?.features.length) {
           callback(result)


### PR DESCRIPTION
fix #577
fix #2491
fix #1546