### PR TITLE
feat: make the tooltip sticky in hover mode for paths

### DIFF
--- a/umap/static/umap/js/modules/rendering/ui.js
+++ b/umap/static/umap/js/modules/rendering/ui.js
@@ -293,6 +293,11 @@ const PathMixin = {
     this.on('popupclose', this._redraw)
   },
 
+  bindTooltip: function (content, options) {
+    options.sticky = !options.permanent
+    this.parentClass.prototype.bindTooltip.call(this, content, options)
+  },
+
   highlightPath: function () {
     this.parentClass.prototype.setStyle.call(this, {
       fillOpacity: Math.sqrt(this.feature.getDynamicOption('fillOpacity', 1.0)),


### PR DESCRIPTION
Until now, it was displayed on the path (line or polygon) "center". So when zoomed in, if the center is not on the screen, the tooltip will not be visible.