### PR TITLE
fix: make sure we sync a line when hitting esc while drawing

### DIFF
--- a/umap/static/umap/js/umap.controls.js
+++ b/umap/static/umap/js/umap.controls.js
@@ -699,6 +699,7 @@ U.Editable = L.Editable.extend({
       if (!event.layer.feature.hasGeom()) {
         event.layer.feature.del()
       } else {
+        event.layer.feature.onCommit()
         event.layer.feature.edit()
       }
     })


### PR DESCRIPTION
I first tried to handle this on Leaflet.Editable side, to make it fire the "editable:edited" event we use to trigger the sync, but deciding what to do with a feature on escape needs some decisions that seems hard to implement in a generic way in Leaflet.Editable.
We call stopDrawing, which then calls cancelDrawing, so here one need to decide if cancelDrawing should keep the already drawn line (but cancel the point being drawn) or cancel everything.
This is why I end up making this change in uMap itself.