### PR TITLE
a11y: turn embeded maps into inert elements

### DIFF
--- a/umap/templates/umap/map_fragment.html
+++ b/umap/templates/umap/map_fragment.html
@@ -1,6 +1,6 @@
 {% load umap_tags %}
 
-<umap-fragment data-settings='{{ map_settings|escape }}'>
+<umap-fragment data-settings='{{ map_settings|escape }}' inert>
 <div id="{{ unique_id }}" class="map_fragment">
 </div>
 </umap-fragment>


### PR DESCRIPTION
One of the side-effects is to make the content of the map un-focusable but we also loose the ability to interact with the map itself.