### PR TITLE
fix: be defensive when getting the backend name from the session

### DIFF
--- a/umap/views.py
+++ b/umap/views.py
@@ -1421,7 +1421,7 @@ class LoginPopupEnd(TemplateView):
     template_name = "umap/login_popup_end.html"
 
     def get(self, *args, **kwargs):
-        backend = self.request.session[BACKEND_SESSION_KEY]
+        backend = self.request.session.get(BACKEND_SESSION_KEY)
         if backend in settings.DEPRECATED_AUTHENTICATION_BACKENDS:
             return HttpResponseRedirect(reverse("user_profile"))
         return super().get(*args, **kwargs)


### PR DESCRIPTION
Seems that in some situation it is not defined.

We have this error in Sentry, but I'm not able to reproduce myself to get a better context:

https://umap.sentry.io/issues/6351694806/?alert_rule_id=14960738&alert_timestamp=1741028858715&alert_type=email&environment=osmfr&notification_uuid=2c437997-d14d-4e0f-a62f-55bd19739ad2&project=4506656504020992&referrer=alert_email