### PR TITLE
fixup: hide home button in edit mode

### DIFF
--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -257,6 +257,9 @@ html[dir="rtl"] .leaflet-tooltip-pane > * {
 .home-button:hover {
     background-color: var(--color-lighterGray);
 }
+.umap-edit-enabled .home-button {
+    display: none;
+}
 
 
 


### PR DESCRIPTION
The button is already on the edit bar.

Would be nicer to have a css transition (like for the bar itself), but at least with this change it is not duplicated.