### PR TITLE
fix: use real redraw for datalayer, instead of hide/show

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -144,11 +144,10 @@ export class DataLayer extends ServerStored {
           if (fields.includes('options.type')) {
             this.resetLayer()
           }
-          this.hide()
           for (const field of fields) {
             this.layer.onEdit(field, builder)
           }
-          this.show()
+          this.redraw()
           break
         case 'remote-data':
           this.fetchRemoteData()
@@ -652,8 +651,7 @@ export class DataLayer extends ServerStored {
 
   redraw() {
     if (!this.isVisible()) return
-    this.hide()
-    this.show()
+    this.eachFeature((feature) => feature.redraw())
   }
 
   edit() {


### PR DESCRIPTION
The problem we've tried to fix is, during sync:
- peer A is editing a feature
- peer B changes the datalayer of this feature
- edit panel is closed for peer A