### PR TITLE
fix: do not fail when trying to read metadata of a missing geojson

### DIFF
--- a/umap/models.py
+++ b/umap/models.py
@@ -526,7 +526,10 @@ class DataLayer(NamedModel):
         metadata = self.settings
         if not metadata:
             # Fallback to file for old datalayers.
-            data = json.loads(self.geojson.read().decode())
+            try:
+                data = json.loads(self.geojson.read().decode())
+            except FileNotFoundError:
+                data = {}
             metadata = data.get("_umap_options")
             if not metadata:
                 metadata = {


### PR DESCRIPTION
Some geojson have been removed by mistake time ago (cf #1003), when someone tries to load a map referencing them, it was until recently just showing an error message, but since recently we try to get the metadata from it, and this will crash.