### PR TITLE
feat: add keyboard shortcut for redo (ctrl+shift+z)

### DIFF
--- a/umap/static/umap/js/modules/help.js
+++ b/umap/static/umap/js/modules/help.js
@@ -36,9 +36,13 @@ const SHORTCUTS = {
     shortcut: 'Modifier+F',
     label: translate('Search location'),
   },
-  CANCEL: {
+  UNDO: {
     shortcut: 'Modifier+Z',
-    label: translate('Cancel edits'),
+    label: translate('Cancel last edit'),
+  },
+  REDO: {
+    shortcut: 'Modifier+Shift+Z',
+    label: translate('Redo last edit'),
   },
   PREVIEW: {
     shortcut: 'Modifier+E',

--- a/umap/static/umap/js/modules/ui/bar.js
+++ b/umap/static/umap/js/modules/ui/bar.js
@@ -126,8 +126,17 @@ export class TopBar extends WithTemplate {
     this.elements.undo.addEventListener('click', () => this._umap.undo())
     this.elements.undo.addEventListener('mouseover', () => {
       this._umap.tooltip.open({
-        content: this._umap.help.displayLabel('CANCEL'),
+        content: this._umap.help.displayLabel('UNDO'),
         anchor: this.elements.undo,
+        position: 'bottom',
+        delay: 500,
+        duration: 5000,
+      })
+    })
+    this.elements.redo.addEventListener('mouseover', () => {
+      this._umap.tooltip.open({
+        content: this._umap.help.displayLabel('REDO'),
+        anchor: this.elements.redo,
         position: 'bottom',
         delay: 500,
         duration: 5000,

--- a/umap/static/umap/js/modules/utils.js
+++ b/umap/static/umap/js/modules/utils.js
@@ -117,6 +117,7 @@ export function escapeHTML(s) {
       'dd',
       'b',
       'i',
+      'kbd',
     ],
     ADD_ATTR: [
       'target',


### PR DESCRIPTION
I've reworked a bit the shortcut handling, as it was only dealing with ctrl/meta only ones (no shift).