### PR TITLE
Remove confirm delete for features and datalayers

### DIFF
--- a/umap/static/umap/js/modules/browser.js
+++ b/umap/static/umap/js/modules/browser.js
@@ -61,7 +61,7 @@ export default class Browser {
     DomEvent.on(zoom_to, 'click', viewFeature)
     DomEvent.on(title, 'click', viewFeature)
     DomEvent.on(edit, 'click', feature.edit, feature)
-    DomEvent.on(del, 'click', feature.confirmDelete, feature)
+    DomEvent.on(del, 'click', feature.del, feature)
     // HOTFIX. Remove when this is released:
     // https://github.com/Leaflet/Leaflet/pull/9052
     DomEvent.disableClickPropagation(row)

--- a/umap/static/umap/js/modules/data/features.js
+++ b/umap/static/umap/js/modules/data/features.js
@@ -278,7 +278,8 @@ class Feature {
         <i class="icon icon-24 icon-delete"></i>${translate('Delete')}
       </button>`)
     button.addEventListener('click', () => {
-      this.confirmDelete().then(() => this._umap.editPanel.close())
+      this.del()
+      this._umap.editPanel.close()
     })
     container.appendChild(button)
   }
@@ -361,17 +362,6 @@ class Feature {
     const popup = new Class(this)
     this.ui.bindPopup(popup)
     return popup.loadContent()
-  }
-
-  async confirmDelete() {
-    const confirmed = await this._umap.dialog.confirm(
-      translate('Are you sure you want to delete the feature?')
-    )
-    if (confirmed) {
-      this.del()
-      return true
-    }
-    return false
   }
 
   del(sync) {
@@ -518,7 +508,7 @@ class Feature {
         icon: 'icon-edit',
       },
       {
-        action: () => this.confirmDelete(),
+        action: () => this.del(),
         title: translate('Delete this feature'),
         icon: 'icon-delete',
       },
@@ -673,7 +663,7 @@ class Feature {
       },
       {
         label: translate('Delete this feature'),
-        action: () => this.confirmDelete(),
+        action: () => this.del(),
       },
       {
         label: translate('Clone this feature'),

--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -1237,23 +1237,14 @@ export class DataLayer {
       translate('Delete layer')
     )
     if (this.isReadOnly()) {
-      DomUtil.addClass(container, 'readonly')
+      container.classList.add('readonly')
     } else {
-      DomEvent.on(edit, 'click', this.edit, this)
-      DomEvent.on(table, 'click', this.tableEdit, this)
-      DomEvent.on(
-        remove,
-        'click',
-        function () {
-          if (!this.isVisible()) return
-          this._umap.dialog
-            .confirm(translate('Are you sure you want to delete this layer?'))
-            .then(() => {
-              this.del()
-            })
-        },
-        this
-      )
+      edit.addEventListener('click', () => this.edit())
+      table.addEventListener('click', () => this.tableEdit())
+      remove.addEventListener('click', () => {
+        if (!this.isVisible()) return
+        this.del()
+      })
     }
     DomEvent.on(toggle, 'click', () => this.toggle())
     DomEvent.on(zoomTo, 'click', this.zoomTo, this)

--- a/umap/tests/integration/test_browser.py
+++ b/umap/tests/integration/test_browser.py
@@ -348,7 +348,6 @@ def test_should_redraw_list_on_feature_delete(live_server, openmap, page, bootst
     buttons = page.locator(".umap-browser .datalayer li .icon-delete")
     expect(buttons).to_have_count(3)
     buttons.first.click()
-    page.locator("dialog").get_by_role("button", name="OK").click()
     expect(buttons).to_have_count(2)
     page.get_by_role("button", name="Undo").click()
     expect(buttons).to_have_count(3)

--- a/umap/tests/integration/test_edit_datalayer.py
+++ b/umap/tests/integration/test_edit_datalayer.py
@@ -61,7 +61,6 @@ def test_cancel_deleting_datalayer_should_restore(
     expect(markers).to_have_count(1)
     page.get_by_role("button", name="Manage layers").click()
     page.locator(".panel.right").get_by_title("Delete layer").click()
-    page.get_by_role("button", name="OK").click()
     expect(markers).to_have_count(0)
     expect(page.get_by_text("test datalayer")).to_be_hidden()
     page.get_by_role("button", name="Undo").click()
@@ -203,7 +202,6 @@ def test_deleting_datalayer_should_remove_from_browser_and_layers_list(
     expect(panel.get_by_text("test datalayer")).to_be_visible()
     expect(edit_panel.get_by_text("test datalayer")).to_be_visible()
     page.locator(".panel.right").get_by_title("Delete layer").click()
-    page.get_by_role("button", name="OK").click()
     expect(panel.get_by_text("test datalayer")).to_be_hidden()
     expect(edit_panel.get_by_text("test datalayer")).to_be_hidden()
 
@@ -217,7 +215,6 @@ def test_deleting_datalayer_should_remove_from_caption(
     page.get_by_role("button", name="Manage layers").click()
     expect(panel.get_by_text("test datalayer")).to_be_visible()
     page.locator(".panel.right").get_by_title("Delete layer").click()
-    page.get_by_role("button", name="OK").click()
     expect(panel.get_by_text("test datalayer")).to_be_hidden()
 
 

--- a/umap/tests/integration/test_owned_map.py
+++ b/umap/tests/integration/test_owned_map.py
@@ -241,7 +241,6 @@ def test_can_delete_datalayer(live_server, map, login, datalayer):
     expect(markers).to_have_count(1)
     page.get_by_role("button", name="Manage layers").click()
     page.locator(".panel.right").get_by_title("Delete layer").click()
-    page.get_by_role("button", name="OK").click()
     with page.expect_response(re.compile(r".*/datalayer/delete/.*")):
         page.get_by_role("button", name="Save").click()
     expect(markers).to_have_count(0)

--- a/umap/tests/integration/test_websocket_sync.py
+++ b/umap/tests/integration/test_websocket_sync.py
@@ -86,7 +86,6 @@ def test_websocket_connection_can_sync_markers(new_page, asgi_live_server, tilel
     # Delete a marker from peer A and check it's been deleted on peer B
     a_first_marker.click(button="right")
     peerA.get_by_role("button", name="Delete this feature").click()
-    peerA.locator("dialog").get_by_role("button", name="OK").click()
     expect(a_marker_pane).to_have_count(1)
     expect(b_marker_pane).to_have_count(1)
 
@@ -166,7 +165,6 @@ def test_websocket_connection_can_sync_polygons(context, asgi_live_server, tilel
     # Delete a polygon from peer A and check it's been deleted on peer B
     a_polygon.click(button="right")
     peerA.get_by_role("button", name="Delete this feature").click()
-    peerA.locator("dialog").get_by_role("button", name="OK").click()
     expect(a_polygons).to_have_count(0)
     expect(b_polygons).to_have_count(0)
 

--- a/umap/tests/integration/test_websocket_sync.py
+++ b/umap/tests/integration/test_websocket_sync.py
@@ -485,7 +485,6 @@ def test_should_sync_datalayers_delete(new_page, asgi_live_server, tilelayer):
 
     # Delete "datalayer 2" in peerA
     peerA.locator(".datalayer").get_by_role("button", name="Delete layer").first.click()
-    peerA.get_by_role("button", name="OK").click()
     expect(peerA.locator(".panel").get_by_text("datalayer 2")).to_be_hidden()
     expect(peerB.locator(".panel").get_by_text("datalayer 2")).to_be_hidden()
 


### PR DESCRIPTION
Now that we have granular undo, I'd say we can simplify the delete process.