### PR TITLE
fix: fix categorized layer crashing with null value

### DIFF
--- a/umap/static/umap/js/modules/utils.js
+++ b/umap/static/umap/js/modules/utils.js
@@ -283,6 +283,8 @@ export function greedyTemplate(str, data, ignore) {
 }
 
 export function naturalSort(a, b, lang) {
+  a ??= ''
+  b ??= ''
   return a
     .toString()
     .toLowerCase()


### PR DESCRIPTION
Do not call toString on a null value