### PR TITLE
fix: fix min-height of select in caption bar

### DIFF
--- a/umap/static/umap/css/bar.css
+++ b/umap/static/umap/css/bar.css
@@ -206,6 +206,7 @@
     margin-top: 0;
     line-height: initial;
     height: initial;
+    min-height: initial;
     width: auto;
     padding: 0 var(--text-margin);
 }


### PR DESCRIPTION
Before:
![Screenshot From 2025-04-08 15-26-28](https://github.com/user-attachments/assets/372d3410-a360-4ff3-a6f2-d7c18a3f26e3)

After:
![Screenshot From 2025-04-08 15-27-44](https://github.com/user-attachments/assets/defb737e-aed3-40b0-91b6-5b8c38675e55)
