### PR TITLE
fix: display back help button in switch fields

### DIFF
--- a/umap/static/umap/js/modules/form/fields.js
+++ b/umap/static/umap/js/modules/form/fields.js
@@ -925,7 +925,8 @@ Fields.Url = class extends Fields.Input {
 Fields.Switch = class extends Fields.CheckBox {
   getTemplate() {
     const label = this.properties.label
-    return `${super.getTemplate()}<label title="${label}" for="${this.id}" data-ref=customLabel>${label}</label>`
+    const help = this.properties.helpEntries?.join() || ''
+    return `${super.getTemplate()}<label title="${label}" for="${this.id}" data-ref=customLabel data-help="${help}">${label}</label>`
   }
 
   build() {


### PR DESCRIPTION
cf #2615

Before:
![image](https://github.com/user-attachments/assets/bac68a6b-6c74-4f10-8d3c-26536dc1ecad)

After:
![image](https://github.com/user-attachments/assets/43c4a0b3-a892-423a-8c20-b7c6304f3182)
