### PR TITLE
fix: do not try to remove a feature not yet added

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -418,6 +418,10 @@ export class DataLayer {
 
   removeFeature(feature, sync) {
     const id = stamp(feature)
+    // This feature was not yet added, may be after
+    // hitting Escape while drawing a new line or
+    // polygon, not yet valid (not enough points)
+    if (!this._index.includes(id)) return
     if (sync !== false) {
       const oldValue = feature.toGeoJSON()
       feature.sync.delete(oldValue)


### PR DESCRIPTION
cf #2625

This happens while drawing a line or polygon and then hitting escape while the path is not yet valid.