### PR TITLE
Adapt chart to match La Suite's expectations

### DIFF
--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -3,7 +3,7 @@ name: Release Charts
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   release:

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -1,0 +1,26 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@v1.7.0
+        with:
+          charts_dir: charts
+          linting: off
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/charts/umap/templates/deployment.yaml
+++ b/charts/umap/templates/deployment.yaml
@@ -66,7 +66,11 @@ spec:
           {{- end }}
           envFrom:
           - secretRef:
+              {{- if .Values.umap.envFromSecret }}
+              name: {{ .Values.umap.envFromSecret }}
+              {{- else }}
               name: {{ include "umap.fullname" . }}-env
+              {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/umap/
@@ -80,7 +84,11 @@ spec:
       volumes:
         - name: config
           secret:
+            {{- if .Values.umap.configFromSecret }}
+            secretName: {{ .Values.umap.configFromSecret }}
+            {{- else }}
             secretName: {{ include "umap.fullname" . }}-config
+            {{- end }}
         - name: statics
           emptyDir: {}
       {{- if .Values.persistence.enabled }}

--- a/charts/umap/templates/secret-config.yaml
+++ b/charts/umap/templates/secret-config.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.umap.configFromSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 type: Opaque
 data:
   umap.conf: {{ .Values.umap.config | b64enc }}
+{{- end }}

--- a/charts/umap/templates/secret-env.yaml
+++ b/charts/umap/templates/secret-env.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.umap.envFromSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,4 +9,5 @@ type: Opaque
 data:
 {{- range $key, $value := .Values.umap.environment }}
   {{ $key }}: "{{ $value | b64enc }}"
+{{- end }}
 {{- end }}

--- a/charts/umap/values.yaml
+++ b/charts/umap/values.yaml
@@ -77,11 +77,18 @@ umap:
     SECRET_KEY: CHANGE_ME
     STATIC_ROOT: /srv/umap/static
     MEDIA_ROOT: /srv/umap/uploads
+  # Configure environment variables using an existing secret in the same namespace.
+  # In this case the values above are not used
+  envFromSecret: null
+
   # You can also provide umap.conf content here:
   config: |
     from umap.settings.base import *
 
     # See: https://github.com/umap-project/umap/blob/master/umap/settings/local.py.sample
+  # Configure config file using an existing secret in the same namespace.
+  # In this case the values above are not used
+  configFromSecret: null
 
 persistence:
   enabled: true


### PR DESCRIPTION
- env vars and config files can be loaded from existing secrets
- chart is deployed on a helm repository

to make the helm repository work with github pages, create an empty orphaned branch called gh-pages, and under settings>pages>source select deploy from branch and use gh-pages