### PR TITLE
fix: allow to save a remote data with unloaded data

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -645,7 +645,7 @@ export class DataLayer {
   }
 
   edit() {
-    if (!this._umap.editEnabled || !this.isLoaded()) {
+    if (!this._umap.editEnabled) {
       return
     }
     const container = DomUtil.create('div', 'umap-layer-properties-container')
@@ -1105,7 +1105,7 @@ export class DataLayer {
 
   async save() {
     if (this.isDeleted) return await this.saveDelete()
-    if (!this.isLoaded()) return
+    if (!this.isRemoteLayer() && !this.isLoaded()) return
     const geojson = this.umapGeoJSON()
     const formData = new FormData()
     formData.append('name', this.options.name)


### PR DESCRIPTION
When loading remote data fails, the layer is in state "unloaded", and thus it was not possible to save it.
This "isLoaded" check is made for non remote layer so that we don't save it by mistake with no data.

Also, let's allow to edit non loaded layers, this check was there when settings was not on db, so not all loaded at map init, again not to override with incomplete metadata.