### PR TITLE
feat: naive support for GeometryCollection as Feature geometry

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -492,8 +492,19 @@ export class DataLayer {
     const features = []
     this.sortFeatures(collection)
     for (const featureJson of collection) {
-      const feature = this.makeFeature(featureJson, sync)
-      if (feature) features.push(feature)
+      if (featureJson.geometry?.type === 'GeometryCollection') {
+        for (const geometry of featureJson.geometry.geometries) {
+          const feature = this.makeFeature({
+            type: 'Feature',
+            geometry,
+            properties: featureJson.properties,
+          })
+          if (feature) features.push(feature)
+        }
+      } else {
+        const feature = this.makeFeature(featureJson, sync)
+        if (feature) features.push(feature)
+      }
     }
     return features
   }


### PR DESCRIPTION
Currently, we just skip those, but sometimes togeojson produces this output from a KML.
This will create one feature per geometry, while in an ideal world this should be a multi, but we lack reliable geometry tools to merge the geometries without risking to create mistakes.
So let's say it's a first improvement.