### PR TITLE
fix: show an error message if saving layer failed

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -1146,6 +1146,9 @@ export class DataLayer {
             await this._umap.saveAll()
           }
         )
+      } else {
+        console.debug(error)
+        Alert.error(translate('Cannot save layer, please try again in a few minutes.'))
       }
     } else {
       // Response contains geojson only if save has conflicted and conflicts have


### PR DESCRIPTION
This could occur when server is down or there is no network.