### PR TITLE
fix: allow to save/undo/sync drag'n'drop of datalayers

### DIFF
--- a/umap/models.py
+++ b/umap/models.py
@@ -551,6 +551,7 @@ class DataLayer(NamedModel):
         if self.old_id:
             metadata["old_id"] = self.old_id
         metadata["id"] = self.pk
+        metadata["rank"] = self.rank
         metadata["permissions"] = {"edit_status": self.edit_status}
         metadata["editMode"] = "advanced" if self.can_edit(request) else "disabled"
         metadata["_referenceVersion"] = self.reference_version

--- a/umap/static/umap/js/modules/browser.js
+++ b/umap/static/umap/js/modules/browser.js
@@ -113,7 +113,7 @@ export default class Browser {
   }
 
   onFormChange() {
-    this._umap.eachBrowsableDataLayer((datalayer) => {
+    this._umap.datalayers.browsable().map((datalayer) => {
       datalayer.resetLayer(true)
       this.updateDatalayer(datalayer)
       if (this._umap.fullPanel?.isOpen()) datalayer.tableEdit()
@@ -136,7 +136,7 @@ export default class Browser {
   onMoveEnd() {
     if (!this.isOpen()) return
     const isListDynamic = this.options.inBbox
-    this._umap.eachBrowsableDataLayer((datalayer) => {
+    this._umap.datalayers.browsable().map((datalayer) => {
       if (!isListDynamic && !datalayer.hasDynamicData()) return
       this.updateDatalayer(datalayer)
     })
@@ -145,7 +145,7 @@ export default class Browser {
   update() {
     if (!this.isOpen()) return
     this.dataContainer.innerHTML = ''
-    this._umap.eachBrowsableDataLayer((datalayer) => {
+    this._umap.datalayers.browsable().map((datalayer) => {
       this.addDataLayer(datalayer, this.dataContainer)
     })
   }
@@ -254,10 +254,10 @@ export default class Browser {
     // If at least one layer is shown, hide it
     // otherwise show all
     let allHidden = true
-    this._umap.eachBrowsableDataLayer((datalayer) => {
+    this._umap.datalayers.browsable().map((datalayer) => {
       if (datalayer.isVisible()) allHidden = false
     })
-    this._umap.eachBrowsableDataLayer((datalayer) => {
+    this._umap.datalayers.browsable().map((datalayer) => {
       datalayer._forcedVisibility = true
       if (allHidden) {
         datalayer.show()

--- a/umap/static/umap/js/modules/caption.js
+++ b/umap/static/umap/js/modules/caption.js
@@ -68,9 +68,11 @@ export default class Caption extends Utils.WithTemplate {
       this.elements.description.hidden = true
     }
     this.elements.datalayersContainer.innerHTML = ''
-    this._umap.eachDataLayerReverse((datalayer) =>
-      this.addDataLayer(datalayer, this.elements.datalayersContainer)
-    )
+    this._umap.datalayers
+      .reverse()
+      .map((datalayer) =>
+        this.addDataLayer(datalayer, this.elements.datalayersContainer)
+      )
     this.addCredits()
     if (this._umap.properties.created_at) {
       const created_at = translate('created at {date}', {
@@ -85,7 +87,7 @@ export default class Caption extends Utils.WithTemplate {
     }
     this._umap.panel.open({ content: this.element }).then(() => {
       // Create the legend when the panel is actually on the DOM
-      this._umap.eachDataLayerReverse((datalayer) => datalayer.renderLegend())
+      this._umap.datalayers.reverse().map((datalayer) => datalayer.renderLegend())
       this._umap.propagate()
     })
   }

--- a/umap/static/umap/js/modules/facets.js
+++ b/umap/static/umap/js/modules/facets.js
@@ -24,7 +24,7 @@ export default class Facets {
       this.selected[name] = selected
     }
 
-    this._umap.eachBrowsableDataLayer((datalayer) => {
+    this._umap.datalayers.browsable().map((datalayer) => {
       datalayer.eachFeature((feature) => {
         for (const name of names) {
           let value = feature.properties[name]

--- a/umap/static/umap/js/modules/form/fields.js
+++ b/umap/static/umap/js/modules/form/fields.js
@@ -560,7 +560,7 @@ Fields.SlideshowDelay = class extends Fields.IntSelect {
 Fields.DataLayerSwitcher = class extends Fields.Select {
   getOptions() {
     const options = []
-    this.builder._umap.eachDataLayerReverse((datalayer) => {
+    this.builder._umap.datalayers.reverse().map((datalayer) => {
       if (
         datalayer.isLoaded() &&
         !datalayer.isDataReadOnly() &&

--- a/umap/static/umap/js/modules/importer.js
+++ b/umap/static/umap/js/modules/importer.js
@@ -243,7 +243,7 @@ export default class Importer extends Utils.WithTemplate {
     this.raw = null
     const layerSelect = this.qs('[name="layer-id"]')
     layerSelect.innerHTML = ''
-    this._umap.eachDataLayerReverse((datalayer) => {
+    this._umap.datalayers.reverse().map((datalayer) => {
       if (datalayer.isLoaded() && !datalayer.isRemoteLayer()) {
         DomUtil.element({
           tagName: 'option',

--- a/umap/static/umap/js/modules/managers.js
+++ b/umap/static/umap/js/modules/managers.js
@@ -1,0 +1,46 @@
+export class DataLayerManager extends Object {
+  add(datalayer) {
+    this[datalayer.id] = datalayer
+  }
+  active() {
+    return Object.values(this)
+      .filter((datalayer) => !datalayer.isDeleted)
+      .sort((a, b) => a.options.rank > b.options.rank)
+  }
+  reverse() {
+    return this.active().reverse()
+  }
+  count() {
+    return this.active().length
+  }
+  find(func) {
+    for (const datalayer of this.reverse()) {
+      if (func.call(datalayer, datalayer)) {
+        return datalayer
+      }
+    }
+  }
+  filter(func) {
+    return this.active().filter(func)
+  }
+  visible() {
+    return this.filter((datalayer) => datalayer.isVisible())
+  }
+  browsable() {
+    return this.reverse().filter((datalayer) => datalayer.allowBrowse())
+  }
+  prev(datalayer) {
+    const browsable = this.browsable()
+    const current = browsable.indexOf(datalayer)
+    const prev = browsable[current - 1] || browsable[browsable.length - 1]
+    if (!prev.canBrowse()) return this.prev(prev)
+    return prev
+  }
+  next(datalayer) {
+    const browsable = this.browsable()
+    const current = browsable.indexOf(datalayer)
+    const next = browsable[current + 1] || browsable[0]
+    if (!next.canBrowse()) return this.next(next)
+    return next
+  }
+}

--- a/umap/static/umap/js/modules/permissions.js
+++ b/umap/static/umap/js/modules/permissions.js
@@ -159,7 +159,7 @@ export class MapPermissions {
         `<fieldset class="separator"><legend>${translate('Datalayers')}</legend></fieldset>`
       )
       container.appendChild(fieldset)
-      this._umap.eachDataLayer((datalayer) => {
+      this._umap.datalayers.active().map((datalayer) => {
         datalayer.permissions.edit(fieldset)
       })
     }

--- a/umap/static/umap/js/modules/rendering/map.js
+++ b/umap/static/umap/js/modules/rendering/map.js
@@ -327,7 +327,7 @@ export const LeafletMap = BaseMap.extend({
     } else if (this.options.defaultView === 'latest') {
       this._umap.onceDataLoaded(() => {
         if (!this._umap.hasData()) return
-        const datalayer = this._umap.firstVisibleDatalayer()
+        const datalayer = this._umap.datalayers.visible()[0]
         let feature
         if (datalayer) {
           const feature = datalayer.getFeatureByIndex(-1)

--- a/umap/static/umap/js/modules/schema.js
+++ b/umap/static/umap/js/modules/schema.js
@@ -10,7 +10,7 @@ import { translate } from './i18n.js'
  * - `type`:        The type of the data
  * - `impacts`:     A list of impacts than happen when this property is updated, among
  *                  'ui', 'data', 'limit-bounds', 'datalayer-index', 'remote-data',
- *                  'background' 'sync'.
+ *                  'background', 'sync', 'datalayer-rank'.
  *
  * - Extra keys are being passed to the FormBuilder automatically.
  */
@@ -435,6 +435,10 @@ export const SCHEMA = {
       ['Wikipedia', translate('Wikipedia')],
     ],
     default: 'Default',
+  },
+  rank: {
+    type: Number,
+    impacts: ['datalayer-rank'],
   },
   remoteData: {
     type: Object,

--- a/umap/static/umap/js/modules/share.js
+++ b/umap/static/umap/js/modules/share.js
@@ -204,8 +204,8 @@ class IframeExporter {
       delete this.queryString.feature
     }
     if (this.options.keepCurrentDatalayers) {
-      this._umap.eachDataLayer((datalayer) => {
-        if (datalayer.isVisible() && datalayer.createdOnServer) {
+      this._umap.datalayers.visible().map((datalayer) => {
+        if (datalayer.createdOnServer) {
           datalayers.push(datalayer.id)
         }
       })

--- a/umap/static/umap/js/modules/slideshow.js
+++ b/umap/static/umap/js/modules/slideshow.js
@@ -66,7 +66,7 @@ export default class Slideshow extends WithTemplate {
   }
 
   defaultDatalayer() {
-    return this._umap.findDataLayer((d) => d.canBrowse())
+    return this._umap.datalayers.find((d) => d.canBrowse())
   }
 
   startSpinner() {

--- a/umap/static/umap/js/modules/ui/bar.js
+++ b/umap/static/umap/js/modules/ui/bar.js
@@ -207,7 +207,7 @@ export class BottomBar extends WithTemplate {
       const select = this.elements.layers
       const selected = select.options[select.selectedIndex].value
       if (!selected) return
-      this._umap.eachDataLayer((datalayer) => {
+      this._umap.datalayers.active().map((datalayer) => {
         datalayer.toggle(datalayer.id === selected)
       })
     })
@@ -228,7 +228,7 @@ export class BottomBar extends WithTemplate {
 
   buildDataLayerSwitcher() {
     this.elements.layers.innerHTML = ''
-    const datalayers = this._umap.datalayersIndex.filter((d) => d.options.inCaption)
+    const datalayers = this._umap.datalayers.filter((d) => d.options.inCaption)
     if (datalayers.length < 2) {
       this.elements.layers.hidden = true
     } else {

--- a/umap/tests/base.py
+++ b/umap/tests/base.py
@@ -131,8 +131,8 @@ class DataLayerFactory(factory.django.DjangoModelFactory):
             data.setdefault("_umap_options", {})
             if "name" in data["_umap_options"] and kwargs["name"] == cls.name:
                 kwargs["name"] = data["_umap_options"]["name"]
-            if "settings" not in kwargs:
-                kwargs["settings"] = data.get("_umap_options", {})
+            kwargs.setdefault("settings", {})
+            kwargs["settings"].update(data.get("_umap_options", {}))
         else:
             data = DATALAYER_DATA.copy()
             data["_umap_options"] = {

--- a/umap/tests/integration/test_optimistic_merge.py
+++ b/umap/tests/integration/test_optimistic_merge.py
@@ -50,6 +50,8 @@ def test_created_markers_are_merged(context, live_server, tilelayer):
         "editMode": "advanced",
         "inCaption": True,
         "id": str(datalayer.pk),
+        "rank": 0,
+        "remoteData": {},
     }
 
     # Now navigate to this map from another tab
@@ -87,6 +89,8 @@ def test_created_markers_are_merged(context, live_server, tilelayer):
         "inCaption": True,
         "editMode": "advanced",
         "id": str(datalayer.pk),
+        "rank": 0,
+        "remoteData": {},
     }
 
     # Now create another marker in the first tab
@@ -105,7 +109,8 @@ def test_created_markers_are_merged(context, live_server, tilelayer):
         "inCaption": True,
         "editMode": "advanced",
         "id": str(datalayer.pk),
-        "permissions": {"edit_status": 1},
+        "rank": 0,
+        "remoteData": {},
     }
 
     # And again
@@ -124,7 +129,8 @@ def test_created_markers_are_merged(context, live_server, tilelayer):
         "inCaption": True,
         "editMode": "advanced",
         "id": str(datalayer.pk),
-        "permissions": {"edit_status": 1},
+        "rank": 0,
+        "remoteData": {},
     }
     expect(marker_pane_p1).to_have_count(4)
 
@@ -145,7 +151,8 @@ def test_created_markers_are_merged(context, live_server, tilelayer):
         "inCaption": True,
         "editMode": "advanced",
         "id": str(datalayer.pk),
-        "permissions": {"edit_status": 1},
+        "rank": 0,
+        "remoteData": {},
     }
     expect(marker_pane_p2).to_have_count(5)
 
@@ -271,7 +278,8 @@ def test_same_second_edit_doesnt_conflict(context, live_server, tilelayer):
         "inCaption": True,
         "editMode": "advanced",
         "id": str(datalayer.pk),
-        "permissions": {"edit_status": 1},
+        "rank": 0,
+        "remoteData": {},
     }
 
 


### PR DESCRIPTION
This also:
- introduces a new DataLayerManager
- removes the _umap_options coming from the geojson form the server
- removes all backup related functions (now we have undo/redo)

fix #2674 