### PR TITLE
fix: display "false" value in the table editor

### DIFF
--- a/umap/static/umap/js/modules/tableeditor.js
+++ b/umap/static/umap/js/modules/tableeditor.js
@@ -96,7 +96,7 @@ export default class TableEditor extends WithTemplate {
       if (inBbox && !feature.isOnScreen(bounds)) return
       const tds = this.properties.map(
         (prop) =>
-          `<td tabindex="0" data-property="${prop}">${feature.properties[prop] || ''}</td>`
+          `<td tabindex="0" data-property="${prop}">${feature.properties[prop] ?? ''}</td>`
       )
       html += `<tr data-feature="${feature.id}"><th><input type="checkbox" /></th>${tds.join('')}</tr>`
     })


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/0353ecd0-3785-49f7-926e-735aad3875ab)


After:
![image](https://github.com/user-attachments/assets/63b1d5b2-8c78-4a8c-bd8e-6cb4d98c0688)

cf #2722