### PR TITLE
feat: make conditional rules non exclusive

### DIFF
--- a/umap/static/umap/js/modules/rules.js
+++ b/umap/static/umap/js/modules/rules.js
@@ -267,7 +267,6 @@ export default class Rules {
     for (const rule of this.rules) {
       if (rule.match(feature.properties)) {
         if (Utils.usableOption(rule.options, option)) return rule.options[option]
-        break
       }
     }
   }


### PR DESCRIPTION
Which means:
- when a given rule matches on a feature (eg. myprop=somevalue) AND for the asked property (eg. for setting the color), we stop a the first matching
- when a given rule matches on a feature BUT does not provides the asked property (that rule does not define a color), we do not stop and pass to the next rules (while until this commit we'd stop anyway)

cf #2722
cf #2334 (that's the part 2 of it)