### PR TITLE
chore: switch from DataLayer.options to DataLayer.properties

### DIFF
--- a/umap/static/umap/js/modules/caption.js
+++ b/umap/static/umap/js/modules/caption.js
@@ -93,7 +93,7 @@ export default class Caption extends Utils.WithTemplate {
   }
 
   addDataLayer(datalayer, parent) {
-    if (!datalayer.options.inCaption) return
+    if (!datalayer.properties.inCaption) return
     const template = `
     <p class="caption-item ${datalayer.cssId}">
       <span class="datalayer-legend"></span>
@@ -101,8 +101,8 @@ export default class Caption extends Utils.WithTemplate {
       <span class="text" data-ref="description"></span>
     </p>`
     const [element, { toolbox, description }] = Utils.loadTemplateWithRefs(template)
-    if (datalayer.options.description) {
-      description.innerHTML = Utils.toHTML(datalayer.options.description)
+    if (datalayer.properties.description) {
+      description.innerHTML = Utils.toHTML(datalayer.properties.description)
     } else {
       description.hidden = true
     }
@@ -110,7 +110,7 @@ export default class Caption extends Utils.WithTemplate {
     parent.appendChild(element)
     // Use textContent for security
     const name = Utils.loadTemplate('<span></span>')
-    name.textContent = datalayer.options.name
+    name.textContent = datalayer.getName()
     toolbox.appendChild(name)
   }
 

--- a/umap/static/umap/js/modules/data/features.js
+++ b/umap/static/umap/js/modules/data/features.js
@@ -340,7 +340,10 @@ class Feature {
   }
 
   hasPopupFooter() {
-    if (this.datalayer.isRemoteLayer() && this.datalayer.options.remoteData.dynamic) {
+    if (
+      this.datalayer.isRemoteLayer() &&
+      this.datalayer.properties.remoteData.dynamic
+    ) {
       return false
     }
     return this._umap.getProperty('displayPopupFooter')

--- a/umap/static/umap/js/modules/importer.js
+++ b/umap/static/umap/js/modules/importer.js
@@ -248,7 +248,7 @@ export default class Importer extends Utils.WithTemplate {
         DomUtil.element({
           tagName: 'option',
           parent: layerSelect,
-          textContent: datalayer.options.name,
+          textContent: datalayer.getName(),
           value: datalayer.id,
         })
       }
@@ -325,13 +325,13 @@ export default class Importer extends Utils.WithTemplate {
       return false
     }
     const layer = this.layer
-    layer.options.remoteData = {
+    layer.properties.remoteData = {
       url: this.url,
       format: this.format,
     }
     if (this._umap.properties.urls.ajax_proxy) {
-      layer.options.remoteData.proxy = true
-      layer.options.remoteData.ttl = SCHEMA.ttl.default
+      layer.properties.remoteData.proxy = true
+      layer.properties.remoteData.ttl = SCHEMA.ttl.default
     }
     layer.fetchRemoteData(true).then((features) => {
       if (features?.length) {

--- a/umap/static/umap/js/modules/permissions.js
+++ b/umap/static/umap/js/modules/permissions.js
@@ -258,7 +258,7 @@ export class DataLayerPermissions {
       {
         edit_status: null,
       },
-      datalayer.options.permissions
+      datalayer.properties.permissions
     )
 
     this.datalayer = datalayer
@@ -314,9 +314,9 @@ export class DataLayerPermissions {
   }
 
   commit() {
-    this.datalayer.options.permissions = Object.assign(
+    this.datalayer.properties.permissions = Object.assign(
       {},
-      this.datalayer.options.permissions,
+      this.datalayer.properties.permissions,
       this.properties
     )
   }

--- a/umap/static/umap/js/modules/rendering/icon.js
+++ b/umap/static/umap/js/modules/rendering/icon.js
@@ -235,8 +235,8 @@ export const Cluster = DivIcon.extend({
   computeTextColor: function (el) {
     let color
     const backgroundColor = this.datalayer.getColor()
-    if (this.datalayer.options.cluster?.textColor) {
-      color = this.datalayer.options.cluster.textColor
+    if (this.datalayer.properties.cluster?.textColor) {
+      color = this.datalayer.properties.cluster.textColor
     }
     return color || DomUtil.TextColorFromBackgroundColor(el, backgroundColor)
   },

--- a/umap/static/umap/js/modules/rendering/layers/base.js
+++ b/umap/static/umap/js/modules/rendering/layers/base.js
@@ -35,7 +35,7 @@ export const LayerMixin = {
     return this._layers
   },
 
-  getEditableOptions: () => [],
+  getEditableProperties: () => [],
 
   onEdit: () => {},
 

--- a/umap/static/umap/js/modules/rendering/layers/classified.js
+++ b/umap/static/umap/js/modules/rendering/layers/classified.js
@@ -15,11 +15,11 @@ const ClassifiedMixin = {
       .filter((k) => k !== 'schemeGroups')
       .sort()
     const key = this.getType().toLowerCase()
-    if (!Utils.isObject(this.datalayer.options[key])) {
-      this.datalayer.options[key] = {}
+    if (!Utils.isObject(this.datalayer.properties[key])) {
+      this.datalayer.properties[key] = {}
     }
-    this.ensureOptions(this.datalayer.options[key])
-    FeatureGroup.prototype.initialize.call(this, [], this.datalayer.options[key])
+    this.ensureOptions(this.datalayer.properties[key])
+    FeatureGroup.prototype.initialize.call(this, [], this.datalayer.properties[key])
     LayerMixin.onInit.call(this, this.datalayer._leafletMap)
   },
 
@@ -117,7 +117,7 @@ export const Choropleth = FeatureGroup.extend({
   },
 
   _getValue: function (feature) {
-    const key = this.datalayer.options.choropleth?.property || 'value'
+    const key = this.datalayer.properties.choropleth?.property || 'value'
     const value = +feature.properties[key]
     if (!Number.isNaN(value)) return value
   },
@@ -130,12 +130,12 @@ export const Choropleth = FeatureGroup.extend({
       this.options.colors = []
       return
     }
-    const mode = this.datalayer.options.choropleth?.mode
-    let classes = +this.datalayer.options.choropleth?.classes || 5
+    const mode = this.datalayer.properties.choropleth?.mode
+    let classes = +this.datalayer.properties.choropleth?.classes || 5
     let breaks
     classes = Math.min(classes, values.length)
     if (mode === 'manual') {
-      const manualBreaks = this.datalayer.options.choropleth?.breaks
+      const manualBreaks = this.datalayer.properties.choropleth?.breaks
       if (manualBreaks) {
         breaks = manualBreaks
           .split(',')
@@ -154,10 +154,10 @@ export const Choropleth = FeatureGroup.extend({
       breaks.push(ss.max(values)) // Needed for computing the legend
     }
     this.options.breaks = breaks || []
-    this.datalayer.options.choropleth.breaks = this.options.breaks
+    this.datalayer.properties.choropleth.breaks = this.options.breaks
       .map((b) => +b.toFixed(2))
       .join(',')
-    let colorScheme = this.datalayer.options.choropleth.brewer
+    let colorScheme = this.datalayer.properties.choropleth.brewer
     if (!colorbrewer[colorScheme]) colorScheme = 'Blues'
     this.options.colors = colorbrewer[colorScheme][this.options.breaks.length - 1] || []
   },
@@ -175,24 +175,27 @@ export const Choropleth = FeatureGroup.extend({
 
   onEdit: function (field, builder) {
     // Only compute the breaks if we're dealing with choropleth
-    if (!field.startsWith('options.choropleth')) return
+    if (!field.startsWith('properties.choropleth')) return
     // If user touches the breaks, then force manual mode
-    if (field === 'options.choropleth.breaks') {
-      this.datalayer.options.choropleth.mode = 'manual'
-      if (builder) builder.helpers['options.choropleth.mode'].fetch()
+    if (field === 'properties.choropleth.breaks') {
+      this.datalayer.properties.choropleth.mode = 'manual'
+      if (builder) builder.helpers['properties.choropleth.mode'].fetch()
     }
     this.compute()
     // If user changes the mode or the number of classes,
     // then update the breaks input value
-    if (field === 'options.choropleth.mode' || field === 'options.choropleth.classes') {
-      if (builder) builder.helpers['options.choropleth.breaks'].fetch()
+    if (
+      field === 'properties.choropleth.mode' ||
+      field === 'properties.choropleth.classes'
+    ) {
+      if (builder) builder.helpers['properties.choropleth.breaks'].fetch()
     }
   },
 
-  getEditableOptions: function () {
+  getEditableProperties: function () {
     return [
       [
-        'options.choropleth.property',
+        'properties.choropleth.property',
         {
           handler: 'Select',
           selectOptions: this.datalayer.allProperties(),
@@ -200,7 +203,7 @@ export const Choropleth = FeatureGroup.extend({
         },
       ],
       [
-        'options.choropleth.brewer',
+        'properties.choropleth.brewer',
         {
           handler: 'Select',
           label: translate('Choropleth color palette'),
@@ -208,7 +211,7 @@ export const Choropleth = FeatureGroup.extend({
         },
       ],
       [
-        'options.choropleth.classes',
+        'properties.choropleth.classes',
         {
           handler: 'Range',
           min: 3,
@@ -219,7 +222,7 @@ export const Choropleth = FeatureGroup.extend({
         },
       ],
       [
-        'options.choropleth.breaks',
+        'properties.choropleth.breaks',
         {
           handler: 'BlurInput',
           label: translate('Choropleth breakpoints'),
@@ -229,7 +232,7 @@ export const Choropleth = FeatureGroup.extend({
         },
       ],
       [
-        'options.choropleth.mode',
+        'properties.choropleth.mode',
         {
           handler: 'MultiChoice',
           default: 'kmeans',
@@ -261,13 +264,13 @@ export const Circles = FeatureGroup.extend({
   },
 
   ensureOptions: function (options) {
-    if (!Utils.isObject(this.datalayer.options.circles.radius)) {
-      this.datalayer.options.circles.radius = {}
+    if (!Utils.isObject(this.datalayer.properties.circles.radius)) {
+      this.datalayer.properties.circles.radius = {}
     }
   },
 
   _getValue: function (feature) {
-    const key = this.datalayer.options.circles.property || 'value'
+    const key = this.datalayer.properties.circles.property || 'value'
     const value = +feature.properties[key]
     if (!Number.isNaN(value)) return value
   },
@@ -276,8 +279,8 @@ export const Circles = FeatureGroup.extend({
     const values = this.getValues()
     this.options.minValue = Math.sqrt(Math.min(...values))
     this.options.maxValue = Math.sqrt(Math.max(...values))
-    this.options.minPX = this.datalayer.options.circles.radius?.min || 2
-    this.options.maxPX = this.datalayer.options.circles.radius?.max || 50
+    this.options.minPX = this.datalayer.properties.circles.radius?.min || 2
+    this.options.maxPX = this.datalayer.properties.circles.radius?.max || 50
   },
 
   onEdit: function (field, builder) {
@@ -298,10 +301,10 @@ export const Circles = FeatureGroup.extend({
     return this._computeRadius(this._getValue(feature))
   },
 
-  getEditableOptions: function () {
+  getEditableProperties: function () {
     return [
       [
-        'options.circles.property',
+        'properties.circles.property',
         {
           handler: 'Select',
           selectOptions: this.datalayer.allProperties(),
@@ -309,7 +312,7 @@ export const Circles = FeatureGroup.extend({
         },
       ],
       [
-        'options.circles.radius.min',
+        'properties.circles.radius.min',
         {
           handler: 'Range',
           label: translate('Min circle radius'),
@@ -319,7 +322,7 @@ export const Circles = FeatureGroup.extend({
         },
       ],
       [
-        'options.circles.radius.max',
+        'properties.circles.radius.max',
         {
           handler: 'Range',
           label: translate('Max circle radius'),
@@ -381,7 +384,8 @@ export const Categorized = FeatureGroup.extend({
 
   _getValue: function (feature) {
     const key =
-      this.datalayer.options.categorized.property || this.datalayer.allProperties()[0]
+      this.datalayer.properties.categorized.property ||
+      this.datalayer.allProperties()[0]
     return feature.properties[key]
   },
 
@@ -403,10 +407,10 @@ export const Categorized = FeatureGroup.extend({
       this.options.colors = []
       return
     }
-    const mode = this.datalayer.options.categorized.mode
+    const mode = this.datalayer.properties.categorized.mode
     let categories = []
     if (mode === 'manual') {
-      const manualCategories = this.datalayer.options.categorized.categories
+      const manualCategories = this.datalayer.properties.categorized.categories
       if (manualCategories) {
         categories = manualCategories.split(',')
       }
@@ -416,8 +420,8 @@ export const Categorized = FeatureGroup.extend({
         .sort(Utils.naturalSort)
     }
     this.options.categories = categories
-    this.datalayer.options.categorized.categories = this.options.categories.join(',')
-    const colorScheme = this.datalayer.options.categorized.brewer
+    this.datalayer.properties.categorized.categories = this.options.categories.join(',')
+    const colorScheme = this.datalayer.properties.categorized.brewer
     this._classes = this.options.categories.length
     if (colorbrewer[colorScheme]?.[this._classes]) {
       this.options.colors = colorbrewer[colorScheme][this._classes]
@@ -428,10 +432,10 @@ export const Categorized = FeatureGroup.extend({
     }
   },
 
-  getEditableOptions: function () {
+  getEditableProperties: function () {
     return [
       [
-        'options.categorized.property',
+        'properties.categorized.property',
         {
           handler: 'Select',
           selectOptions: this.datalayer.allProperties(),
@@ -439,7 +443,7 @@ export const Categorized = FeatureGroup.extend({
         },
       ],
       [
-        'options.categorized.brewer',
+        'properties.categorized.brewer',
         {
           handler: 'Select',
           label: translate('Color palette'),
@@ -447,7 +451,7 @@ export const Categorized = FeatureGroup.extend({
         },
       ],
       [
-        'options.categorized.categories',
+        'properties.categorized.categories',
         {
           handler: 'BlurInput',
           label: translate('Categories'),
@@ -455,7 +459,7 @@ export const Categorized = FeatureGroup.extend({
         },
       ],
       [
-        'options.categorized.mode',
+        'properties.categorized.mode',
         {
           handler: 'MultiChoice',
           default: 'alpha',
@@ -468,17 +472,19 @@ export const Categorized = FeatureGroup.extend({
 
   onEdit: function (field, builder) {
     // Only compute the categories if we're dealing with categorized
-    if (!field.startsWith('options.categorized') && field !== 'options.type') return
+    if (!field.startsWith('properties.categorized') && field !== 'properties.type') {
+      return
+    }
     // If user touches the categories, then force manual mode
-    if (field === 'options.categorized.categories') {
-      this.datalayer.options.categorized.mode = 'manual'
-      if (builder) builder.helpers['options.categorized.mode'].fetch()
+    if (field === 'properties.categorized.categories') {
+      this.datalayer.properties.categorized.mode = 'manual'
+      if (builder) builder.helpers['properties.categorized.mode'].fetch()
     }
     this.compute()
     // If user changes the mode
     // then update the categories input value
-    if (field === 'options.categorized.mode') {
-      if (builder) builder.helpers['options.categorized.categories'].fetch()
+    if (field === 'properties.categorized.mode') {
+      if (builder) builder.helpers['properties.categorized.categories'].fetch()
     }
   },
 

--- a/umap/static/umap/js/modules/rendering/layers/cluster.js
+++ b/umap/static/umap/js/modules/rendering/layers/cluster.js
@@ -27,8 +27,8 @@ export const Cluster = L.MarkerClusterGroup.extend({
 
   initialize: function (datalayer) {
     this.datalayer = datalayer
-    if (!Utils.isObject(this.datalayer.options.cluster)) {
-      this.datalayer.options.cluster = {}
+    if (!Utils.isObject(this.datalayer.properties.cluster)) {
+      this.datalayer.properties.cluster = {}
     }
     const options = {
       polygonOptions: {
@@ -36,8 +36,8 @@ export const Cluster = L.MarkerClusterGroup.extend({
       },
       iconCreateFunction: (cluster) => new ClusterIcon(datalayer, cluster),
     }
-    if (this.datalayer.options.cluster?.radius) {
-      options.maxClusterRadius = this.datalayer.options.cluster.radius
+    if (this.datalayer.properties.cluster?.radius) {
+      options.maxClusterRadius = this.datalayer.properties.cluster.radius
     }
     L.MarkerClusterGroup.prototype.initialize.call(this, options)
     LayerMixin.onInit.call(this, this.datalayer._leafletMap)
@@ -81,9 +81,9 @@ export const Cluster = L.MarkerClusterGroup.extend({
     return L.MarkerClusterGroup.prototype.removeLayer.call(this, layer)
   },
 
-  getEditableOptions: () => [
+  getEditableProperties: () => [
     [
-      'options.cluster.radius',
+      'properties.cluster.radius',
       {
         handler: 'BlurIntInput',
         placeholder: translate('Clustering radius'),
@@ -91,7 +91,7 @@ export const Cluster = L.MarkerClusterGroup.extend({
       },
     ],
     [
-      'options.cluster.textColor',
+      'properties.cluster.textColor',
       {
         handler: 'TextColorPicker',
         placeholder: translate('Auto'),
@@ -101,12 +101,12 @@ export const Cluster = L.MarkerClusterGroup.extend({
   ],
 
   onEdit: function (field, builder) {
-    if (field === 'options.cluster.radius') {
+    if (field === 'properties.cluster.radius') {
       // No way to reset radius of an already instanciated MarkerClusterGroup...
       this.datalayer.resetLayer(true)
       return
     }
-    if (field === 'options.color') {
+    if (field === 'properties.color') {
       this.options.polygonOptions.color = this.datalayer.getColor()
     }
   },

--- a/umap/static/umap/js/modules/rendering/layers/heat.js
+++ b/umap/static/umap/js/modules/rendering/layers/heat.js
@@ -20,10 +20,10 @@ export const Heat = L.HeatLayer.extend({
 
   initialize: function (datalayer) {
     this.datalayer = datalayer
-    L.HeatLayer.prototype.initialize.call(this, [], this.datalayer.options.heat)
+    L.HeatLayer.prototype.initialize.call(this, [], this.datalayer.properties.heat)
     LayerMixin.onInit.call(this, this.datalayer._leafletMap)
-    if (!Utils.isObject(this.datalayer.options.heat)) {
-      this.datalayer.options.heat = {}
+    if (!Utils.isObject(this.datalayer.properties.heat)) {
+      this.datalayer.properties.heat = {}
     }
   },
 
@@ -31,9 +31,11 @@ export const Heat = L.HeatLayer.extend({
     if (layer instanceof Marker) {
       let latlng = layer.getLatLng()
       let alt
-      if (this.datalayer.options.heat?.intensityProperty) {
+      if (this.datalayer.properties.heat?.intensityProperty) {
         alt = Number.parseFloat(
-          layer.feature.properties[this.datalayer.options.heat.intensityProperty || 0]
+          layer.feature.properties[
+            this.datalayer.properties.heat.intensityProperty || 0
+          ]
         )
         latlng = new LatLng(latlng.lat, latlng.lng, alt)
       }
@@ -66,9 +68,9 @@ export const Heat = L.HeatLayer.extend({
     return latLngBounds(this._latlngs)
   },
 
-  getEditableOptions: () => [
+  getEditableProperties: () => [
     [
-      'options.heat.radius',
+      'properties.heat.radius',
       {
         handler: 'Range',
         min: 10,
@@ -79,7 +81,7 @@ export const Heat = L.HeatLayer.extend({
       },
     ],
     [
-      'options.heat.intensityProperty',
+      'properties.heat.intensityProperty',
       {
         handler: 'BlurInput',
         placeholder: translate('Heatmap intensity property'),
@@ -89,12 +91,12 @@ export const Heat = L.HeatLayer.extend({
   ],
 
   onEdit: function (field, builder) {
-    if (field === 'options.heat.intensityProperty') {
+    if (field === 'properties.heat.intensityProperty') {
       this.datalayer.resetLayer(true) // We need to repopulate the latlngs
       return
     }
-    if (field === 'options.heat.radius') {
-      this.options.radius = this.datalayer.options.heat.radius
+    if (field === 'properties.heat.radius') {
+      this.options.radius = this.datalayer.properties.heat.radius
     }
     this._updateOptions()
   },

--- a/umap/static/umap/js/modules/sync/updaters.js
+++ b/umap/static/umap/js/modules/sync/updaters.js
@@ -52,8 +52,8 @@ export class DataLayerUpdater extends BaseUpdater {
 
   update({ key, metadata, value }) {
     const datalayer = this.getDataLayerFromID(metadata.id)
-    if (key === 'options') {
-      datalayer.setOptions(value)
+    if (key === 'properties') {
+      datalayer.setProperties(value)
     } else if (Utils.fieldInSchema(key)) {
       Utils.setObjectValue(datalayer, key, value)
     } else {

--- a/umap/static/umap/js/modules/ui/bar.js
+++ b/umap/static/umap/js/modules/ui/bar.js
@@ -233,7 +233,7 @@ export class BottomBar extends WithTemplate {
 
   buildDataLayerSwitcher() {
     this.elements.layers.innerHTML = ''
-    const datalayers = this._umap.datalayers.filter((d) => d.options.inCaption)
+    const datalayers = this._umap.datalayers.filter((d) => d.properties.inCaption)
     if (datalayers.length < 2) {
       this.elements.layers.hidden = true
     } else {

--- a/umap/static/umap/js/modules/umap.js
+++ b/umap/static/umap/js/modules/umap.js
@@ -638,20 +638,20 @@ export default class Umap {
     this.fire('dataloaded')
   }
 
-  createDataLayer(options = {}, sync = true) {
-    options.name =
-      options.name || `${translate('Layer')} ${this.datalayers.count() + 1}`
-    const datalayer = new DataLayer(this, this._leafletMap, options)
+  createDataLayer(properties = {}, sync = true) {
+    properties.name =
+      properties.name || `${translate('Layer')} ${this.datalayers.count() + 1}`
+    const datalayer = new DataLayer(this, this._leafletMap, properties)
 
     if (sync !== false) {
-      datalayer.sync.upsert(datalayer.options)
+      datalayer.sync.upsert(datalayer.properties)
     }
     return datalayer
   }
 
-  createDirtyDataLayer(options) {
-    const datalayer = this.createDataLayer(options, true)
-    return datalayer
+  // TODO: remove me in favor of createDataLayer
+  createDirtyDataLayer(properties) {
+    return this.createDataLayer(properties, true)
   }
 
   newDataLayer() {
@@ -1496,7 +1496,7 @@ export default class Umap {
       datalayer.renderToolbox(row)
       const builder = new MutatingForm(
         datalayer,
-        [['options.name', { handler: 'EditableText' }]],
+        [['properties.name', { handler: 'EditableText' }]],
         { className: 'umap-form-inline' }
       )
       const form = builder.build()


### PR DESCRIPTION
This aligns with what we do on other uMap objects. `options` should be only used in the Leaflet world.