### PR TITLE
feat: add management command to purge old versions

### DIFF
--- a/docs/maintenance/management_commands.md
+++ b/docs/maintenance/management_commands.md
@@ -1,0 +1,14 @@
+# Management commands
+
+## Command `purge_old_versions`
+
+Old versions are usually deleted on save of a datalayer, but we still keep [`UMAP_KEEP_VERSIONS`](../config/settings.md#umap_keep_versions).
+Let's say after some time even those versions could be deleted, to save some space.
+This is to be used as a daily cron.
+
+
+### Options
+
+* `--dry-run`: only print candidate datalayers without any effective deletion.
+* `--days`: number of days prior to today considered for deletion, only select datalayers within that time range (days => today)
+* `--initial`:

--- a/docs/maintenance/management_commands.md
+++ b/docs/maintenance/management_commands.md
@@ -1,14 +1,83 @@
 # Management commands
 
-## Command `purge_old_versions`
+## `anonymous_edit_url`
+
+Retrieve anonymous edit url of a map, from its id.
+
+Eg.: `umap anonymous_edit_url 1234`
+
+### options
+
+* `--lang LANG`: Language code to use in the URL (default `en`).
+
+## `clean_tilelayer.py`
+
+Clean tilelayers in map settings.
+
+This will simply replace the URL in maps settings:
+
+    umap clean_tilelayer http://my.old/url/template http://my.new/url/template
+
+This will replace the whole tilelayer in maps settings by the one with this name:
+
+    umap clean_tilelayer http://my.old/url/template "some string"
+
+This will replace the whole tilelayer in maps settings by the one with this id:
+
+    umap clean_tilelayer http://my.old/url/template an_id
+
+This will delete the whole tilelayer from maps settings:
+
+    umap clean_tilelayer http://my.old/url/template
+
+To get the available tilelayers in db (available for users):
+
+    umap clean_tilelayer --available
+
+To get statistics of tilelayers usage in db (including custom ones):
+
+    umap clean_tilelayer --available
+
+### Options
+
+* `--available`: list known tilelayers.
+
+
+## `empty_trash`
+
+Remove maps in trash.
+Eg.: `umap empty_trash --days 7`
+
+### Options
+
+* `--days DAYS`: number of days to consider maps for removal
+* `--dry-run`: pretend to delete but just report
+
+## `import_pictograms`
+
+Import pictograms from a folder.
+
+### Options
+
+* `--attribution ATTRIBUTION`: attribution of the imported pictograms
+* `--extensions EXTENSIONS [EXTENSIONS ...]`: optional list of extensins to process
+* `--exclude EXCLUDE [EXCLUDE ...]`: optional list of files or dirs to exclude
+* `--force`: update picto if it already exists
+
+
+## `migrate_to_s3`
+
+Migrate latest datalayers from filesystem to S3.
+
+## `purge_old_versions`
 
 Old versions are usually deleted on save of a datalayer, but we still keep [`UMAP_KEEP_VERSIONS`](../config/settings.md#umap_keep_versions).
 Let's say after some time even those versions could be deleted, to save some space.
-This is to be used as a daily cron.
-
+This is to be used as a daily cron, and by default it will select every datalayer last modified
+exactly 360 days ago.
 
 ### Options
 
 * `--dry-run`: only print candidate datalayers without any effective deletion.
-* `--days`: number of days prior to today considered for deletion, only select datalayers within that time range (days => today)
-* `--initial`:
+* `--days-ago`: select datalayers which where last modified that many days ago (default: 360).
+* `--days-to-select`: how many days before `days-ago` to consider, use `0` to put not limit (default: 1).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,8 @@ nav:
       - Nginx: deploy/nginx.md
       - ASGI: deploy/asgi.md
       - WSGI: deploy/wsgi.md
+  - Maintenance:
+      - Management commands: maintenance/management_commands.md
   - Changelog: changelog.md
 theme:
   name: material

--- a/umap/management/commands/purge_old_versions.py
+++ b/umap/management/commands/purge_old_versions.py
@@ -1,0 +1,56 @@
+import sys
+from datetime import datetime, timedelta
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from umap.models import DataLayer
+
+
+class Command(BaseCommand):
+    help = "Delete versions from datalayers which last modified date is x days ago. Eg.: umap prune_old_versions --days 30"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--days",
+            help="Number of days to consider datalayers for versions removal",
+            default=360,
+            type=int,
+        )
+        parser.add_argument(
+            "--dry-run",
+            help="Pretend to delete but just report",
+            action="store_true",
+        )
+        parser.add_argument(
+            "--initial",
+            help="To be added at first run: also select older layers",
+            action="store_true",
+        )
+
+    def handle(self, *args, **options):
+        if settings.STORAGES["data"]["BACKEND"] != "umap.storage.fs.FSDataStorage":
+            msg = (
+                "This command is only available for filesystem storage. "
+                "For S3 storage, use lifecycle rule in the bucket."
+            )
+            sys.exit(msg)
+        days = options["days"]
+        since = (datetime.utcnow() - timedelta(days=days)).date()
+        print(f"Deleting versions for datalayer unmodified since {since}")
+        filters = {"modified_at__date": since}
+        if options["initial"]:
+            filters = {"modified_at__lt": since}
+        datalayers = DataLayer.objects.filter(**filters)
+        print(f"Selected {len(datalayers)} datalayers")
+        for layer in datalayers:
+            layer_id = layer.uuid
+            layer_name = layer.name
+            last_modified = layer.modified_at.date()
+            deleted = 0
+            if not options["dry_run"]:
+                deleted = layer.geojson.storage.purge_old_versions(layer, keep=1)
+                layer.geojson.storage.purge_gzip(layer)
+            print(
+                f"Deleted {deleted} old versions of `{layer_name}` ({layer_id}), unmodified since {last_modified}"
+            )

--- a/umap/management/commands/purge_old_versions.py
+++ b/umap/management/commands/purge_old_versions.py
@@ -43,6 +43,7 @@ class Command(BaseCommand):
             filters = {"modified_at__lt": since}
         datalayers = DataLayer.objects.filter(**filters)
         print(f"Selected {len(datalayers)} datalayers")
+        total_deleted = 0
         for layer in datalayers:
             layer_id = layer.uuid
             layer_name = layer.name
@@ -51,6 +52,11 @@ class Command(BaseCommand):
             if not options["dry_run"]:
                 deleted = layer.geojson.storage.purge_old_versions(layer, keep=1)
                 layer.geojson.storage.purge_gzip(layer)
+                total_deleted += deleted
             print(
                 f"Deleted {deleted} old versions of `{layer_name}` ({layer_id}), unmodified since {last_modified}"
             )
+        if not options["dry_run"]:
+            print(f"Successfully deleted {total_deleted} geojson files.")
+        else:
+            print(f"The command would delete {total_deleted} geojson files.")

--- a/umap/tests/test_purge_old_versions.py
+++ b/umap/tests/test_purge_old_versions.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from django.core.files.base import ContentFile
+from django.core.management import call_command
+
+from .base import DataLayerFactory, MapFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_purge_old_versions(map):
+    map2 = MapFactory()
+    other_layer = DataLayerFactory(map=map2)
+    recent_layer = DataLayerFactory(map=map)
+    old_layer = DataLayerFactory(map=map)
+    older_layer = DataLayerFactory(map=map)
+    other_layer.geojson.storage.save(
+        Path(other_layer.geojson.storage._base_path(other_layer))
+        / f"{other_layer.uuid}_1440918537.geojson",
+        ContentFile("{}"),
+    )
+    with mock.patch("django.utils.timezone.now") as mocked:
+        mocked.return_value = datetime.utcnow() - timedelta(days=7)
+        old_layer.save()
+        old_layer.geojson.storage.save(
+            Path(old_layer.geojson.storage._base_path(old_layer))
+            / f"{old_layer.uuid}_1440918537.geojson",
+            ContentFile("{}"),
+        )
+        old_layer.geojson.storage.save(
+            Path(old_layer.geojson.storage._base_path(old_layer))
+            / f"{old_layer.uuid}_1440918537.geojson.gz",
+            ContentFile("{}"),
+        )
+        mocked.return_value = datetime.utcnow() - timedelta(days=12)
+        older_layer.save()
+        older_layer.geojson.storage.save(
+            Path(older_layer.geojson.storage._base_path(older_layer))
+            / f"{older_layer.uuid}_1340918536.geojson",
+            ContentFile("{}"),
+        )
+        older_layer.geojson.storage.save(
+            Path(older_layer.geojson.storage._base_path(older_layer))
+            / f"{older_layer.uuid}_1340918536.geojson.gz",
+            ContentFile("{}"),
+        )
+    assert len(recent_layer.versions) == 1
+    assert len(old_layer.versions) == 2
+    assert len(older_layer.versions) == 2
+    assert len(other_layer.versions) == 2
+    root = old_layer.geojson.storage._base_path(old_layer)
+    # Files including gz for map 1
+    # recent layer geojson
+    # old layer 2 geojson + 1 gzip
+    # older layer 2 geojson + 1 gzip
+    assert len(old_layer.geojson.storage.listdir(root)[1]) == 7
+    call_command("purge_old_versions", "--days=7", "--dry-run")
+    assert len(recent_layer.versions) == 1
+    assert len(old_layer.versions) == 2
+    assert len(older_layer.versions) == 2
+    assert len(other_layer.versions) == 2
+    assert len(old_layer.geojson.storage.listdir(root)[1]) == 7
+    call_command("purge_old_versions", "--days=9")
+    assert len(recent_layer.versions) == 1
+    assert len(old_layer.versions) == 2
+    assert len(older_layer.versions) == 2
+    assert len(other_layer.versions) == 2
+    assert len(old_layer.geojson.storage.listdir(root)[1]) == 7
+    call_command("purge_old_versions", "--days=7")
+    assert len(recent_layer.versions) == 1
+    assert len(old_layer.versions) == 1
+    assert len(older_layer.versions) == 2
+    assert len(other_layer.versions) == 2
+    # Files including gz for map 1
+    # recent layer geojson
+    # old layer 1 geojson
+    # older layer 2 geojson + 1 gz
+    assert len(old_layer.geojson.storage.listdir(root)[1]) == 5
+    call_command("purge_old_versions", "--days=7", "--initial")
+    assert len(recent_layer.versions) == 1
+    assert len(old_layer.versions) == 1
+    assert len(older_layer.versions) == 1
+    assert len(other_layer.versions) == 2
+    # Files including gz for map 1
+    # recent layer geojson
+    # old layer 1 geojson
+    # older layer 1 geojson
+    assert len(old_layer.geojson.storage.listdir(root)[1]) == 3

--- a/umap/tests/test_purge_old_versions.py
+++ b/umap/tests/test_purge_old_versions.py
@@ -57,19 +57,19 @@ def test_purge_old_versions(map):
     # old layer 2 geojson + 1 gzip
     # older layer 2 geojson + 1 gzip
     assert len(old_layer.geojson.storage.listdir(root)[1]) == 7
-    call_command("purge_old_versions", "--days=7", "--dry-run")
+    call_command("purge_old_versions", "--days-ago=7", "--dry-run")
     assert len(recent_layer.versions) == 1
     assert len(old_layer.versions) == 2
     assert len(older_layer.versions) == 2
     assert len(other_layer.versions) == 2
     assert len(old_layer.geojson.storage.listdir(root)[1]) == 7
-    call_command("purge_old_versions", "--days=9")
+    call_command("purge_old_versions", "--days-ago=9")
     assert len(recent_layer.versions) == 1
     assert len(old_layer.versions) == 2
     assert len(older_layer.versions) == 2
     assert len(other_layer.versions) == 2
     assert len(old_layer.geojson.storage.listdir(root)[1]) == 7
-    call_command("purge_old_versions", "--days=7")
+    call_command("purge_old_versions", "--days-ago=7")
     assert len(recent_layer.versions) == 1
     assert len(old_layer.versions) == 1
     assert len(older_layer.versions) == 2
@@ -79,7 +79,7 @@ def test_purge_old_versions(map):
     # old layer 1 geojson
     # older layer 2 geojson + 1 gz
     assert len(old_layer.geojson.storage.listdir(root)[1]) == 5
-    call_command("purge_old_versions", "--days=7", "--initial")
+    call_command("purge_old_versions", "--days-ago=7", "--days-to-select=0")
     assert len(recent_layer.versions) == 1
     assert len(old_layer.versions) == 1
     assert len(older_layer.versions) == 1


### PR DESCRIPTION
Old versions are usually deleted on save of a datalayer, but we still keep UMAP_KEEP_VERSION. Let's say after some time even those versions could be deleted, to save some space.