### PR TITLE
fix: fix dragged marker not savable when in cluster layer

### DIFF
--- a/umap/static/umap/js/modules/rendering/layers/cluster.js
+++ b/umap/static/umap/js/modules/rendering/layers/cluster.js
@@ -110,4 +110,11 @@ export const Cluster = L.MarkerClusterGroup.extend({
       this.options.polygonOptions.color = this.datalayer.getColor()
     }
   },
+
+  _moveChild: (layer, from, to) => {
+    // Extend parent method, so to remove remove/addLayer,
+    // to let our own dragend event listener be called
+    // cf https://github.com/umap-project/umap/issues/2749
+    layer._latlng = to
+  },
 })


### PR DESCRIPTION
The parent `_moveChild` method will call removeLayer then addLayer again (to add it to the correct cluster), but this will then deactivate further event listener, including our dragEnd listener, which is the one responsible for adding the change in the save/undo/sync queue.
One other option would be to make that our dragEnd call comes before their, but it's harder to do, as it is markercluster `addLayer` itself to decide in which order those listener are added, and thus called.

fix #2749