### PR TITLE
fix: do not try to evaluate queryset until it's fully constructed

### DIFF
--- a/umap/views.py
+++ b/umap/views.py
@@ -26,6 +26,7 @@ from django.core.mail import send_mail
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.core.signing import BadSignature, Signer, TimestampSigner
 from django.core.validators import URLValidator, ValidationError
+from django.db.models import QuerySet
 from django.http import (
     Http404,
     HttpResponse,
@@ -353,7 +354,7 @@ class Search(PaginatorMixin, TemplateView, PublicMapsMixin, SearchMixin):
         qs = self.get_search_queryset(Map.public.all())
         qs_count = 0
         results = []
-        if qs is not None:
+        if isinstance(qs, QuerySet):
             qs = qs.filter(share_status=Map.PUBLIC).order_by("-modified_at")
             qs_count = qs.count()
             results = self.paginate(qs)
@@ -381,7 +382,7 @@ class UserDashboard(PaginatorMixin, DetailView, SearchMixin):
     def get_maps(self):
         qs = Map.private.filter(is_template=False)
         search_qs = self.get_search_queryset(qs)
-        if search_qs is not None:
+        if isinstance(search_qs, QuerySet):
             qs = search_qs
         qs = qs.for_user(self.object)
         return qs.order_by("-modified_at")
@@ -403,7 +404,7 @@ class UserTemplates(PaginatorMixin, DetailView, SearchMixin):
     def get_maps(self):
         qs = Map.private.filter(is_template=True)
         search_qs = self.get_search_queryset(qs)
-        if search_qs is not None:
+        if isinstance(search_qs, QuerySet):
             qs = search_qs
         qs = qs.for_user(self.object)
         return qs.order_by("-modified_at")


### PR DESCRIPTION
Here, the if on the queryset was doing a full search on the map table with "template=false" as only where clause. On big server, this hurts a lot.