### PR TITLE
fix: crash when editing description in textarea

### DIFF
--- a/umap/static/umap/js/modules/form/fields.js
+++ b/umap/static/umap/js/modules/form/fields.js
@@ -131,12 +131,13 @@ class BaseElement {
 
 Fields.Textarea = class extends BaseElement {
   getTemplate() {
-    return `<textarea placeholder="${this.properties.placeholder || ''}" data-ref=textarea></textarea>`
+    return `<textarea placeholder="${this.properties.placeholder || ''}" name="${this.name}" data-ref=textarea></textarea>`
   }
 
   build() {
     super.build()
     this.textarea = this.elements.textarea
+    this.input = this.textarea
     this.fetch()
     this.textarea.addEventListener(
       'input',

--- a/umap/tests/integration/test_tableeditor.py
+++ b/umap/tests/integration/test_tableeditor.py
@@ -69,6 +69,8 @@ def test_table_editor(live_server, openmap, datalayer, page):
     page.goto(f"{live_server.url}{openmap.get_absolute_url()}?edit")
     page.get_by_role("button", name="Manage layers").click()
     page.locator(".panel").get_by_title("Edit properties in a table").click()
+    page.locator("td[data-property=description]").dblclick()
+    page.locator('textarea[name="description"]').fill("nice new description")
     page.get_by_text("Add a new property").click()
     page.locator("dialog").locator("input").fill("newprop")
     page.locator("dialog").get_by_role("button", name="OK").click()
@@ -83,6 +85,7 @@ def test_table_editor(live_server, openmap, datalayer, page):
         page.get_by_role("button", name="Save").click()
     saved = DataLayer.objects.last()
     data = json.loads(Path(saved.geojson.path).read_text())
+    assert data["features"][0]["properties"]["description"] == "nice new description"
     assert data["features"][0]["properties"]["newprop"] == "newvalue"
     assert "name" not in data["features"][0]["properties"]
 


### PR DESCRIPTION
I guess this was broken when refactoring the fields, as the tableeditor expects an "input" property for Input and for Textarea…