### PR TITLE
fix: update brewer color palettes when layer properties change

### DIFF
--- a/umap/static/umap/js/modules/form/fields.js
+++ b/umap/static/umap/js/modules/form/fields.js
@@ -364,6 +364,9 @@ Fields.Select = class extends BaseElement {
   }
 
   getOptions() {
+    if (this.properties.getOptions) {
+      return this.properties.getOptions()
+    }
     return this.properties.selectOptions
   }
 

--- a/umap/static/umap/js/modules/rendering/layers/classified.js
+++ b/umap/static/umap/js/modules/rendering/layers/classified.js
@@ -447,7 +447,7 @@ export const Categorized = FeatureGroup.extend({
         {
           handler: 'Select',
           label: translate('Color palette'),
-          selectOptions: this.getColorSchemes(this._classes),
+          getOptions: () => this.getColorSchemes(this._classes),
         },
       ],
       [
@@ -481,6 +481,8 @@ export const Categorized = FeatureGroup.extend({
       if (builder) builder.helpers['properties.categorized.mode'].fetch()
     }
     this.compute()
+    // Rebuild list of color palettes when aggregation property changes.
+    builder?.helpers['properties.categorized.brewer']?.fetch()
     // If user changes the mode
     // then update the categories input value
     if (field === 'properties.categorized.mode') {


### PR DESCRIPTION
The color palettes we display depend on the amount of classes, thus the number of categories, thus the number of different values on the selected column of the data.

So when selecting another column, we need to update the color palettes list.

The fix itself consists in allowing the `selectOptions` property to be a callable, so be dynamically updated each time we build the options (on fetch call).