### PR TITLE
wip: add markers in datalayer's pane instead of in their own dedicated pane

### DIFF
--- a/umap/static/umap/js/modules/data/features.js
+++ b/umap/static/umap/js/modules/data/features.js
@@ -374,7 +374,7 @@ class Feature {
     this.datalayer = datalayer
     // FIXME should be in layer/ui
     this.ui.options.renderer = this.datalayer.renderer
-    this.ui.options.pane = this.datalayer.pane
+    this.ui.options.pane = this.datalayer.markersPane
   }
 
   disconnectFromDataLayer(datalayer) {
@@ -783,7 +783,7 @@ class Path extends Feature {
   connectToDataLayer(datalayer) {
     super.connectToDataLayer(datalayer)
     // We keep markers on their own layer on top of the paths.
-    this.ui.options.pane = this.datalayer.pane
+    this.ui.options.pane = this.datalayer.pathsPane
   }
 
   edit(event) {

--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -47,10 +47,6 @@ export class DataLayer {
     this._propertiesIndex = []
 
     this._leafletMap = leafletMap
-    this.parentPane = this._leafletMap.getPane('overlayPane')
-    this.pane = this._leafletMap.createPane(`datalayer${stamp(this)}`, this.parentPane)
-    // FIXME: should be on layer
-    this.renderer = L.svg({ pane: this.pane })
     this.defaultProperties = {
       displayOnLoad: true,
       inCaption: true,
@@ -63,9 +59,18 @@ export class DataLayer {
     // Do not save it later.
     delete data._referenceVersion
     data.id = data.id || crypto.randomUUID()
-
     this.setProperties(data)
+
+    this.parentPane = this._leafletMap.getPane('overlayPane')
+    this.pane = this._leafletMap.createPane(`datalayer-${this.id}`, this.parentPane)
     this.pane.dataset.id = this.id
+    this.pathsPane = Utils.loadTemplate('<div class="umap-paths-pane"></div>')
+    this.markersPane = Utils.loadTemplate('<div class="umap-markers-pane"></div>')
+    this.pane.appendChild(this.pathsPane)
+    this.pane.appendChild(this.markersPane)
+    // FIXME: should be on layer
+    this.renderer = L.svg({ pane: this.pathsPane })
+
     if (this.properties.rank === undefined) {
       this.properties.rank = this._umap.datalayers.count()
     }

--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -58,6 +58,13 @@ html[dir="rtl"] .leaflet-tooltip-pane>* {
     bottom: var(--current-footer-height);
 }
 
+.umap-paths-pane {
+    z-index: var(--zindex-paths);
+}
+
+.umap-markers-pane {
+    z-index: var(--zindex-markers);
+}
 
 /* *********** */
 /* Controls    */

--- a/umap/static/umap/vars.css
+++ b/umap/static/umap/vars.css
@@ -61,9 +61,12 @@
     --zindex-panels: 440;
     --zindex-controls: 430;
     --zindex-dragover: 410;
+    --zindex-markers: 405;
+    --zindex-paths: 401;
 
     --block-shadow: 0 1px 7px var(--color-mediumGray);
 }
+
 .dark {
     --background-color: var(--color-darkGray);
     --text-color: #efefef;


### PR DESCRIPTION
By default, Leaflet has two panes:
- one for markers
- one for paths (polygon and polylines), below the markers one

In uMap, we have made that each datalayer create its own pane, so to follow the datalayer order, but we only added polyline and polygons in that pane. Markers were still added to their pane, above datalayers panes. In this case, the orders or markers between them was "random", in the sense that even if the datalayers are still created in the right order, the markers are added in the order the ajax requests return.

This proposal changes that, and markers are now added in the same pane as polygons and polylines.

This will make that markers will now follow the datalayer order.

But the downside is that, before, it was impossible for a polygon or path to cover a marker, which will now be possible.

So maybe we want to be more ambitious, and instead of puting paths and markers in same pane, to make that datalayers will create two panes, one for paths (as currently) and one for markers, which would always be above all paths dedicated panes.

Before:

![Screenshot From 2025-07-01 11-45-49](https://github.com/user-attachments/assets/44b912b0-21ef-488f-a4da-20c11871a2da)


After:

![Screenshot From 2025-07-01 11-46-13](https://github.com/user-attachments/assets/2e5a97b6-d3c1-472e-bd29-824af4d78fef)
