### PR TITLE
feat: only show import error when in edit mode

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -611,11 +611,13 @@ export class DataLayer {
         break
       default:
         console.debug(geojson)
-        Alert.error(
-          translate('Skipping unknown geometry.type: {type}', {
-            type: geometry.type || 'undefined',
-          })
-        )
+        if (this._umap.editEnabled) {
+          Alert.error(
+            translate('Skipping unknown geometry.type: {type}', {
+              type: geometry.type || 'undefined',
+            })
+          )
+        }
     }
     if (feature && !feature.isEmpty()) {
       this.addFeature(feature)


### PR DESCRIPTION
We don't want visitors to have this error message they cannot do anything about.

fix #2804