### PR TITLE
feat: use DataLayer order to set marker z-index

### DIFF
--- a/umap/static/umap/js/modules/data/features.js
+++ b/umap/static/umap/js/modules/data/features.js
@@ -371,8 +371,6 @@ class Feature {
 
   connectToDataLayer(datalayer) {
     this.datalayer = datalayer
-    // FIXME should be in layer/ui
-    this.ui.options.renderer = this.datalayer.renderer
   }
 
   disconnectFromDataLayer(datalayer) {
@@ -776,12 +774,6 @@ class Path extends Feature {
 
   _setLatLngs(latlngs) {
     this.ui.setLatLngs(latlngs)
-  }
-
-  connectToDataLayer(datalayer) {
-    super.connectToDataLayer(datalayer)
-    // We keep markers on their own layer on top of the paths.
-    this.ui.options.pane = this.datalayer.pane
   }
 
   edit(event) {

--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -273,8 +273,10 @@ export class DataLayer {
     const Class = LAYER_MAP[this.properties.type] || DefaultLayer
     this.layer = new Class(this)
     // Rendering layer changed, so let's force reset the feature rendering too.
-    this.features.forEach((feature) => feature.makeUI())
-    this.features.forEach((feature) => this.showFeature(feature))
+    this.features.forEach((feature) => {
+      feature.makeUI()
+      this.showFeature(feature)
+    })
     if (visible) this.show()
     this.propagateRemote()
   }
@@ -743,6 +745,9 @@ export class DataLayer {
 
   reindex() {
     this.features.sort(this.sortKey)
+    if (this.isBrowsable()) {
+      this.resetLayer(true)
+    }
   }
 
   _editMetadata(container) {

--- a/umap/static/umap/js/modules/rendering/ui.js
+++ b/umap/static/umap/js/modules/rendering/ui.js
@@ -238,6 +238,14 @@ export const LeafletMarker = Marker.extend({
     this._redraw()
     this._resetZIndex()
   },
+
+  _resetZIndex() {
+    // Override Leaflet default behaviour, which set the zIndex
+    // according to feature's y coordinate, and group features
+    // zIndex by their datalayer order
+    this._zIndex = this.feature.datalayer.getDOMOrder()
+    this._updateZIndex(0)
+  },
 })
 
 const PathMixin = {
@@ -294,6 +302,11 @@ const PathMixin = {
 
   _onDrag: function () {
     if (this._tooltip) this._tooltip.setLatLng(this.getCenter())
+  },
+
+  beforeAdd: function (map) {
+    this.options.renderer = this.feature.datalayer.renderer
+    this.parentClass.prototype.beforeAdd.call(this, map)
   },
 
   onAdd: function (map) {

--- a/umap/static/umap/js/modules/umap.js
+++ b/umap/static/umap/js/modules/umap.js
@@ -1525,6 +1525,7 @@ export default class Umap {
           const oldRank = datalayer.rank
           datalayer.rank = rank
           datalayer.sync.update('options.rank', rank, oldRank)
+          datalayer.redraw()
         }
       })
       this.sync.commitBatch()

--- a/umap/tests/integration/test_basics.py
+++ b/umap/tests/integration/test_basics.py
@@ -43,7 +43,7 @@ def test_create_map_with_cursor(page, live_server, tilelayer):
             "margin-left: -16px; "
             "margin-top: -40px; "
             "transform: translate3d(200px, 200px, 0px); "
-            "z-index: 200;"
+            "z-index: 0;"
         ),
     )
 


### PR DESCRIPTION
We use to respect the datalayers order for path but not for markers, which can be frustrating sometimes, now it's the case.