### PR TITLE
feat: import "false" MultiPoint

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -601,6 +601,14 @@ export class DataLayer {
         // FIXME: deal with MultiPoint
         feature = new Point(this._umap, this, geojson, id)
         break
+      case 'MultiPoint':
+        if (geometry.coordinates?.length === 1) {
+          geojson.geometry.coordinates = geojson.geometry.coordinates[0]
+          feature = new Point(this._umap, this, geojson, id)
+        } else if (this._umap.editEnabled) {
+          Alert.error(translate('Can process MultiPoint'))
+        }
+        break
       case 'MultiLineString':
       case 'LineString':
         feature = new LineString(this._umap, this, geojson, id)

--- a/umap/tests/integration/test_import.py
+++ b/umap/tests/integration/test_import.py
@@ -557,6 +557,38 @@ def test_import_multipolyline(live_server, page, tilelayer):
     expect(paths).to_have_count(1)
 
 
+def test_import_false_multipoint(live_server, page, tilelayer):
+    data = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {
+                    "coordinates": [[1.43661447777346, 43.59853484073553]],
+                    "type": "MultiPoint",
+                },
+                "properties": {"name": "foo bar"},
+            }
+        ],
+    }
+    page.goto(f"{live_server.url}/map/new/")
+    page.get_by_title("Open browser").click()
+    layers = page.locator(".umap-browser .datalayer")
+    markers = page.locator(".leaflet-marker-icon")
+    expect(markers).to_have_count(0)
+    expect(layers).to_have_count(0)
+    button = page.get_by_title("Import data")
+    expect(button).to_be_visible()
+    button.click()
+    textarea = page.locator(".umap-import textarea")
+    textarea.fill(json.dumps(data))
+    page.locator('select[name="format"]').select_option("geojson")
+    page.get_by_role("button", name="Import data", exact=True).click()
+    # A layer has been created
+    expect(layers).to_have_count(1)
+    expect(markers).to_have_count(1)
+
+
 def test_should_not_import_empty_coordinates(live_server, page, tilelayer):
     data = {
         "type": "FeatureCollection",


### PR DESCRIPTION
When a geometry is of type "MultiPoint" but only have one coordinates pair, let's import it as a single point.