### PR TITLE
feat: invert all SVG pictograms, not only local ones

### DIFF
--- a/umap/static/umap/js/modules/rendering/icon.js
+++ b/umap/static/umap/js/modules/rendering/icon.js
@@ -273,7 +273,7 @@ export function setContrast(icon, parent, src, bgcolor) {
   if (DomUtil.contrastedColor(parent, bgcolor)) {
     // Decide whether to switch svg to white or not, but do it
     // only for internal SVG, as invert could do weird things
-    if (Utils.isPath(src) && src.endsWith('.svg') && src !== SCHEMA.iconUrl.default) {
+    if (src.endsWith('.svg') && src !== SCHEMA.iconUrl.default) {
       // Must be called after icon container is added to the DOM
       // An image
       icon.style.filter = 'invert(1)'


### PR DESCRIPTION
When creating a map from a template, or importing a umap dump in another instance, the picto paths have been made absolute, so the invert is not done when needed. Let's fix that, and see how much is a trouble for users using their custom made SVG…