### PR TITLE
Fix img center rules caption

### DIFF
--- a/umap/static/umap/map.css
+++ b/umap/static/umap/map.css
@@ -844,8 +844,14 @@ a.umap-control-caption,
 .rules-caption .color-box {
     width: 24px;
     height: 24px;
+    line-height: 24px;
     display: inline-block;
     margin-right: var(--text-margin);
+    vertical-align: middle;
+    text-align: center;
+}
+
+.rules-caption .color-box img {
     vertical-align: middle;
 }
 


### PR DESCRIPTION
<img width="324" height="289" alt="Screenshot From 2025-07-10 17-13-59" src="https://github.com/user-attachments/assets/7be15222-c23d-4e77-9e92-dae218228e54" />

<img width="324" height="289" alt="Screenshot From 2025-07-10 17-13-38" src="https://github.com/user-attachments/assets/cf5c6311-7c1f-4aad-8efe-f7ae5f28999e" />

