### PR TITLE
feat: do not hide layers not appearing in the bottom datalayer switcher

### DIFF
--- a/umap/static/umap/js/modules/ui/bar.js
+++ b/umap/static/umap/js/modules/ui/bar.js
@@ -213,7 +213,9 @@ export class BottomBar extends WithTemplate {
       const selected = select.options[select.selectedIndex].value
       if (!selected) return
       this._umap.datalayers.active().map((datalayer) => {
-        datalayer.toggle(datalayer.id === selected)
+        if (datalayer.properties.inCaption !== false) {
+          datalayer.toggle(datalayer.id === selected)
+        }
       })
     })
     this.redraw()


### PR DESCRIPTION
We only show datalayer with "inCaption=true" in the switcher, so let's be consistent and only show/hide those layers.

fix #2856