### PR TITLE
fix: focus whatever first button or a tag in a contextmenu

### DIFF
--- a/umap/static/umap/js/modules/ui/contextmenu.js
+++ b/umap/static/umap/js/modules/ui/contextmenu.js
@@ -75,7 +75,7 @@ export default class ContextMenu extends Positioned {
     } else {
       this.computePosition([left, top])
     }
-    this.container.querySelector('li button').focus()
+    this.container.querySelector('button, a').focus()
     this.container.addEventListener(
       'keydown',
       (event) => {


### PR DESCRIPTION
Sometimes we have no button but just a tags (eg. the menu in the top edit bar)