### PR TITLE
fix: only compute clusters for visible features

### DIFF
--- a/umap/static/umap/js/modules/data/features.js
+++ b/umap/static/umap/js/modules/data/features.js
@@ -782,7 +782,7 @@ export class Point extends Feature {
   }
 
   zoomTo(event) {
-    if (this.datalayer.isClustered() && !this.ui._icon) {
+    if (this.datalayer.isClustered() && this.ui._cluster) {
       this.ui._cluster.zoomToCoverage().then(() => {
         this.ui._cluster.spiderfy()
       })


### PR DESCRIPTION
Our naive algorithm complexity is related to the number of clusters, so let's not compute clusters outside of the map bounds.