### PR TITLE
perf: remove unused DataLayer._geojson data backup

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -43,7 +43,6 @@ export class DataLayer {
     this._umap = umap
     this.sync = umap.syncEngine.proxy(this)
     this.features = new FeatureManager()
-    this._geojson = null
     this._propertiesIndex = []
 
     this._leafletMap = leafletMap
@@ -306,7 +305,6 @@ export class DataLayer {
   fromGeoJSON(geojson, sync = true) {
     if (!geojson) return []
     const features = this.addData(geojson, sync)
-    this._geojson = geojson
     this._needsFetch = false
     this.onDataLoaded()
     this.dataChanged()
@@ -328,12 +326,6 @@ export class DataLayer {
       await this.fetchRemoteData()
     } else {
       this.fromGeoJSON(geojson, false)
-    }
-  }
-
-  backupData() {
-    if (this._geojson) {
-      this._geojson_bk = Utils.CopyJSON(this._geojson)
     }
   }
 
@@ -751,7 +743,7 @@ export class DataLayer {
     const properties = Utils.CopyJSON(this.properties)
     properties.name = translate('Clone of {name}', { name: this.properties.name })
     delete properties.id
-    const geojson = Utils.CopyJSON(this._geojson)
+    const geojson = Utils.CopyJSON(this.umapGeoJSON())
     const datalayer = this._umap.createDirtyDataLayer(properties)
     datalayer.fromGeoJSON(geojson)
     return datalayer
@@ -1331,7 +1323,6 @@ export class DataLayer {
       ? { 'X-Datalayer-Reference': this._referenceVersion }
       : {}
     const status = await this._trySave(saveURL, headers, formData)
-    this._geojson = geojson
     return status
   }
 
@@ -1371,7 +1362,6 @@ export class DataLayer {
 
       this.setReferenceVersion({ response, sync: true })
 
-      this.backupData()
       this.connectToMap()
       this.redraw() // Needed for reordering features
       return true

--- a/umap/tests/integration/test_edit_datalayer.py
+++ b/umap/tests/integration/test_edit_datalayer.py
@@ -69,6 +69,7 @@ def test_cancel_deleting_datalayer_should_restore(
 
 
 def test_can_clone_datalayer(live_server, openmap, login, datalayer, page):
+    assert DataLayer.objects.count() == 1
     page.goto(f"{live_server.url}{openmap.get_absolute_url()}?edit")
     page.get_by_title("Open browser").click()
     layers = page.locator(".umap-browser .datalayer")
@@ -81,6 +82,9 @@ def test_can_clone_datalayer(live_server, openmap, login, datalayer, page):
     page.get_by_role("button", name="Clone").click()
     expect(layers).to_have_count(2)
     expect(markers).to_have_count(2)
+    with page.expect_response(re.compile(".*/datalayer/create/.*")):
+        page.get_by_role("button", name="Save").click()
+    assert DataLayer.objects.count() == 2
 
 
 def test_can_change_icon_class(live_server, openmap, page):


### PR DESCRIPTION
Now that we have the undo/redo feature, we don't use this anymore.