### PR TITLE
fix: update map options from umap properties before computing tilelayer

### DIFF
--- a/umap/static/umap/js/modules/rendering/map.js
+++ b/umap/static/umap/js/modules/rendering/map.js
@@ -154,6 +154,7 @@ const ControlsMixin = {
 
 const ManageTilelayerMixin = {
   initTileLayers: function () {
+    this.pullProperties()
     this.tilelayers = []
     for (const props of this.options.tilelayers) {
       const layer = this.createTileLayer(props)


### PR DESCRIPTION
Otherwise, when trying to set a custom tilelayer, this will not be reflected in the map unless save and reload.