### PR TITLE
fix: moving marker in cluster was not making the map dirty

### DIFF
--- a/umap/static/umap/js/modules/rendering/ui.js
+++ b/umap/static/umap/js/modules/rendering/ui.js
@@ -135,7 +135,9 @@ const PointMixin = {
   _onDragEnd(event) {
     if (this._cluster) {
       delete this._originalLatLng
-      this.feature.datalayer.dataChanged()
+      this.once('editable:edited', () => {
+        this.feature.datalayer.dataChanged()
+      })
     }
     this.feature.edit(event)
   },

--- a/umap/tests/integration/test_cluster.py
+++ b/umap/tests/integration/test_cluster.py
@@ -51,3 +51,35 @@ def test_can_open_feature_on_browser_click(live_server, page, map):
     expect(page.get_by_text("can you see me ?")).to_be_visible()
     page.get_by_text("again one another point").click()
     expect(page.get_by_text("and me ?")).to_be_visible()
+
+
+def test_can_drag_single_marker_in_cluster_layer(live_server, page, tilelayer, openmap):
+    DataLayerFactory(map=openmap, data=DATALAYER_DATA)
+    page.goto(f"{live_server.url}{openmap.get_absolute_url()}?edit#7/46.920/3.340")
+
+    marker = page.locator(".umap-div-icon")
+    map = page.locator("#map")
+
+    expect(page.locator(".edit-undo")).to_be_disabled()
+    # Drag marker
+    old_bbox = marker.bounding_box()
+    marker.first.drag_to(map, target_position={"x": 250, "y": 250})
+    assert marker.bounding_box() != old_bbox
+    expect(page.locator(".edit-undo")).to_be_enabled()
+
+
+def test_can_drag_marker_in_cluster(live_server, page, tilelayer, openmap):
+    DataLayerFactory(map=openmap, data=DATALAYER_DATA)
+    page.goto(f"{live_server.url}{openmap.get_absolute_url()}?edit#18/46.92/3.34")
+
+    marker = page.locator(".umap-div-icon")
+    cluster = page.locator(".umap-cluster-icon")
+    map = page.locator("#map")
+    expect(marker).to_have_count(0)
+
+    expect(page.locator(".edit-undo")).to_be_disabled()
+    cluster.click()
+    marker.first.drag_to(map, target_position={"x": 250, "y": 250})
+    expect(page.locator(".edit-undo")).to_be_enabled()
+    # There is no more cluster
+    expect(marker).to_have_count(2)


### PR DESCRIPTION
This was because a race condition between the onDraggend of the marker (which was then calling a dataChanged, thus a remove/readd of the marker) and the onDraggend of the marker editor (which is responsable of setting the marker in dirty state, thus the map).

So this was resulting in the map not being in "savable" state after moving a marker.