### PR TITLE
fix: properly convert MultiPoint to Point

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -607,6 +607,7 @@ export class DataLayer {
       case 'MultiPoint':
         if (geometry.coordinates?.length === 1) {
           geojson.geometry.coordinates = geojson.geometry.coordinates[0]
+          geojson.geometry.type = 'Point'
           feature = new Point(this._umap, this, geojson, id)
         } else if (this._umap.editEnabled) {
           Alert.error(translate('Cannot process MultiPoint'))


### PR DESCRIPTION
When a MultiPoint has only one member, we import it as a Point, but until now we do not change the type, which then creates an invalid MultiPoint (with only one "coordinates" member).

fix #2906