### PR TITLE
chore: make datalayer dirty when duplicate id has been found

### DIFF
--- a/umap/static/umap/js/modules/managers.js
+++ b/umap/static/umap/js/modules/managers.js
@@ -59,6 +59,7 @@ export class FeatureManager extends Map {
     if (this.has(feature.id)) {
       console.error('Duplicate id', feature, this.get(feature.id))
       feature.id = Utils.generateId()
+      feature.datalayer._found_duplicate_id = true
     }
     this.set(feature.id, feature)
   }

--- a/umap/static/umap/js/modules/umap.js
+++ b/umap/static/umap/js/modules/umap.js
@@ -1269,6 +1269,18 @@ export default class Umap {
     this.drop.enable()
     this.fire('edit:enabled')
     this.initSyncEngine()
+    this.datalayers.active().forEach((datalayer) => {
+      if (!datalayer.isReadOnly() && datalayer._found_duplicate_id) {
+        datalayer._found_duplicate_id = false
+        // Force user to resave those datalayers
+        datalayer.sync.update(
+          'properties.name',
+          datalayer.properties.name,
+          datalayer.properties.name
+        )
+        Alert.info(translate('Layer has been migrated, please save the map.'))
+      }
+    })
   }
 
   disableEdit() {


### PR DESCRIPTION
Our first algo to create features id has created a lot of duplicate, so we need to recompute them, which can take quite a lot of CPU when there are a lot of features. So let's warn the editor about this so they can save the layer again, resetting the ids.

cf #2813 