### PR TITLE
fix: make dialogs more responsive

### DIFF
--- a/umap/static/umap/css/dialog.css
+++ b/umap/static/umap/css/dialog.css
@@ -1,17 +1,17 @@
 .umap-dialog {
-    z-index: var(--zindex-dialog);
-    margin: auto;
-    margin-top: 100px;
-    width: var(--dialog-width);
-    max-width: 100vw;
-    max-height: 80vh;
-    padding: 20px;
-    border: 1px solid #222;
-    background-color: var(--background-color);
-    color: var(--text-color);
-    border-radius: 5px;
-    overflow-y: auto;
-    height: fit-content;
+  z-index: var(--zindex-dialog);
+  margin: auto;
+  margin-top: calc(var(--header-height) + var(--panel-gutter));
+  width: var(--dialog-width);
+  max-width: 100vw;
+  max-height: 80vh;
+  padding: 20px;
+  border: 1px solid #222;
+  background-color: var(--background-color);
+  color: var(--text-color);
+  border-radius: 5px;
+  overflow-y: auto;
+  height: fit-content;
 }
 .umap-dialog ul + h4 {
   margin-top: var(--box-margin);
@@ -36,6 +36,15 @@
   margin: unset;
   padding: unset;
 }
+@media all and (max-width: 480px) {
+  :root {
+    --dialog-width: calc(100vw - var(--control-size) * 2 - var(--panel-gutter) * 4);
+  }
+  .umap-dialog {
+    padding: var(--small-box-padding);
+  }
+}
+
 /* hack for Firefox */
 @-moz-document url-prefix() {
   [data-component="no-dialog"]:not([hidden]) {


### PR DESCRIPTION
Before:

<img width="321" height="568" alt="Capture d’écran, le 2025-09-09 à 10 51 04" src="https://github.com/user-attachments/assets/f6dc5edc-3707-478e-a49a-d9ae224d1267" />

After:
<img width="322" height="571" alt="Capture d’écran, le 2025-09-09 à 10 50 42" src="https://github.com/user-attachments/assets/0be3e751-c064-4787-9f33-9f3e184700d7" />

