### PR TITLE
feat: add export in CSV with WKT geometry

### DIFF
--- a/umap/static/umap/js/modules/formatter.js
+++ b/umap/static/umap/js/modules/formatter.js
@@ -32,6 +32,10 @@ export const EXPORT_FORMATS = {
     ext: '.csv',
     filetype: 'text/csv',
   },
+  wkt: {
+    ext: '.csv',
+    filetype: 'text/csv',
+  },
 }
 
 export class Formatter {
@@ -169,6 +173,8 @@ export class Formatter {
     switch (format) {
       case 'csv':
         return await this.toCSV(features)
+      case 'wkt':
+        return await this.toWKT(features)
       case 'gpx':
         return await this.toGPX(features)
       case 'kml':
@@ -211,6 +217,18 @@ export class Formatter {
       delete row._umap_options
       row.Latitude = center.lat
       row.Longitude = center.lng
+      table.push(row)
+    }
+    return csv2geojson.dsv.csvFormat(table)
+  }
+
+  async toWKT(features) {
+    const table = []
+    const betterknown = await import('../../vendors/betterknown/betterknown.mjs')
+    for (const feature of features) {
+      const row = feature.toGeoJSON().properties
+      delete row._umap_options
+      row.geometry = betterknown.geoJSONToWkt(feature.geometry)
       table.push(row)
     }
     return csv2geojson.dsv.csvFormat(table)

--- a/umap/tests/integration/test_export_map.py
+++ b/umap/tests/integration/test_export_map.py
@@ -215,6 +215,25 @@ test two,53.725145179688646,2.9700064980570517,"""
     )
 
 
+def test_wkt_export(map, live_server, bootstrap, page):
+    page.goto(f"{live_server.url}{map.get_absolute_url()}?share")
+    button = page.get_by_role("button", name="wkt")
+    expect(button).to_be_visible()
+    with page.expect_download() as download_info:
+        button.click()
+    download = download_info.value
+    assert download.suggested_filename == "test_map.csv"
+    path = Path("/tmp/") / download.suggested_filename
+    download.save_as(path)
+    assert (
+        path.read_text()
+        == """name,geometry,description
+name poly,"POLYGON ((11.25 53.585984,10.151367 52.975108,12.689209 52.167194,14.084473 53.199452,12.634277 53.618579,11.25 53.585984,11.25 53.585984))",
+test one,POINT (-0.274658 52.57635),Some description
+test two,"LINESTRING (-0.571289 54.476422,0.439453 54.610255,1.724854 53.448807,4.163818 53.988395,5.306396 53.533778,6.591797 53.709714,7.042236 53.350551)","""
+    )
+
+
 def test_gpx_export(map, live_server, bootstrap, page):
     page.goto(f"{live_server.url}{map.get_absolute_url()}?share")
     button = page.get_by_role("button", name="gpx")


### PR DESCRIPTION
This allow to keep the complex geometries (polygon, polyline), and may also allow to reimport the data in Grist so to edit them there and add them in remote data.