### PR TITLE
fix: do no try to redraw a feature not on the map

### DIFF
--- a/umap/static/umap/js/modules/data/features.js
+++ b/umap/static/umap/js/modules/data/features.js
@@ -665,7 +665,7 @@ class Feature {
   }
 
   redraw() {
-    if (this.datalayer?.isVisible()) {
+    if (this.datalayer?.isVisible() && this.ui?.isVisible()) {
       if (this.getUIClass() !== this.ui.getClass()) {
         this.datalayer.hideFeature(this)
         this.makeUI()

--- a/umap/static/umap/js/modules/rendering/ui.js
+++ b/umap/static/umap/js/modules/rendering/ui.js
@@ -111,6 +111,10 @@ const FeatureMixin = {
   onCommit: function () {
     this.feature.onCommit()
   },
+
+  isVisible() {
+    return Boolean(this._map?.hasLayer(this))
+  },
 }
 
 const PointMixin = {


### PR DESCRIPTION
This happens for example when saving a layer while it has some features filtered.