### PR TITLE
fix: better way to login from map using OAuth / OSM

### DIFF
--- a/umap/static/umap/js/modules/umap.js
+++ b/umap/static/umap/js/modules/umap.js
@@ -1274,16 +1274,20 @@ export default class Umap {
 
   askForLogin() {
     const promise = new Promise((resolve) => {
-      window.onLogin = () => {
-        const url = this.urls.get('whoami', { map_id: this.id })
-        this.server.get(url).then(([data]) => {
-          this.properties.user = data.user
-          if (!this.id) {
-            this.properties.permissions.owner = { ...data.user }
-          }
-          this.render(['user', 'properties.permissions'])
-          resolve()
-        })
+      const bc = new BroadcastChannel('auth')
+      bc.onmessage = (event) => {
+        if (event.data === 'auth:ok') {
+          bc.postMessage('auth:close')
+          const url = this.urls.get('whoami', { map_id: this.id })
+          this.server.get(url).then(([data]) => {
+            this.properties.user = data.user
+            if (!this.id) {
+              this.properties.permissions.owner = { ...data.user }
+            }
+            this.render(['user', 'properties.permissions'])
+            resolve()
+          })
+        }
       }
     })
     window.open(this.urls.get('login'))

--- a/umap/templates/umap/login_popup_end.html
+++ b/umap/templates/umap/login_popup_end.html
@@ -5,19 +5,28 @@
 </h3>
 <script type="text/javascript">
   function proceed() {
-    if (window.opener?.onLogin) {
-      // We are in the normal process login
-      window.opener.onLogin()
-      window.close()
-    } else {
-      // we may be in login process that includes a magic link, so user
-      // has opened a new window from this link, and we cannot close it then.
-      window.location.href = '{% url "user_dashboard" %}'
+    if (window.BroadcastChannel) {
+      const bc = new BroadcastChannel('auth')
+      bc.onmessage = (event) => {
+        if (event.data === 'auth:close') {
+          window.close()
+        }
+      }
+      bc.postMessage('auth:ok')
     }
+    // In case the login was started in Javascript, the broadcasting whould close this
+    // window, so we wait for the broacasting to have a chance to finish the communication
+    // before trying to load the dashboard.
+    window.setTimeout(() => {
+      // We should arrive here in three situations:
+      // - the browser is older than 2022 and does not have BroadcastChannel API
+      // - the login process has opened another page/tab (like using a magic link)
+      // - the login was started from a content page (so not from the map page, and not in JS)
+      window.location.href = '{% url "user_dashboard" %}'
+    }, 1000)
   }
 
   proceed()
 // To handle errors, this template should be integrated into your authentication error message page
-// Note that you can call any window.opener function like window.opener.func
 
 </script>


### PR DESCRIPTION
Using window.opener is not possible anymore, since

https://github.com/openstreetmap/openstreetmap-website/commit/2ff4d6a4e633e479568572090eb6a16074103cd9

So we switched to BroadcastChannel (which is baseline 2022, so one year ahead of our actual baseline, but we have a fallback on the user dashboard when this API is not available, so that should be fine)