### PR TITLE
fix: Switch should not have label or help in inheritable mode

### DIFF
--- a/umap/static/umap/js/modules/form/fields.js
+++ b/umap/static/umap/js/modules/form/fields.js
@@ -1029,11 +1029,14 @@ Fields.Url = class extends Fields.Input {
 
 Fields.Switch = class extends Fields.CheckBox {
   getLabelTemplate() {
-    return ''
+    if (!this.properties.inheritable) return ''
+    return super.getLabelTemplate()
   }
   getTemplate() {
-    const label = this.properties.label
-    const help = this.properties.helpEntries?.join() || ''
+    const label = this.properties.inheritable ? '' : this.properties.label
+    const help = this.properties.inheritable
+      ? ''
+      : this.properties.helpEntries?.join() || ''
     return `${super.getTemplate()}<label for="${this.id}" data-ref=customLabel data-help="${help}">${label}</label>`
   }
 


### PR DESCRIPTION
In this case, label and help are displayed in the wrapper ( close to the "define" button).