### PR TITLE
fix: do not save data to the server for remote layers

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -1197,7 +1197,8 @@ export class DataLayer {
   }
 
   umapGeoJSON() {
-    const geojson = this._umap.formatter.toFeatureCollection(this.features.all())
+    const features = this.isRemoteLayer() ? [] : this.features.all()
+    const geojson = this._umap.formatter.toFeatureCollection(features)
     geojson._umap_options = this.properties
     return geojson
   }
@@ -1234,12 +1235,12 @@ export class DataLayer {
   async save() {
     if (this.isDeleted) return await this.saveDelete()
     if (!this.isRemoteLayer() && !this.isLoaded()) return
-    const geojson = this.umapGeoJSON()
     const formData = new FormData()
     formData.append('name', this.properties.name)
     formData.append('display_on_load', !!this.properties.displayOnLoad)
     formData.append('rank', this.rank)
     formData.append('settings', this.prepareProperties())
+    const geojson = this.umapGeoJSON()
     // Filename support is shaky, don't do it for now.
     const blob = new Blob([JSON.stringify(geojson)], { type: 'application/json' })
     formData.append('geojson', blob)

--- a/umap/tests/integration/conftest.py
+++ b/umap/tests/integration/conftest.py
@@ -35,7 +35,7 @@ def new_page(context):
             else None,
         )
         page.on("pageerror", lambda exc: print(f"{prefix} uncaught exception: {exc}"))
-        if not bool(os.environ.get("PWDEBUG", False)):
+        if not bool(os.environ.get("PWDEBUG", os.environ.get("FORCE_TILES", False))):
             page.route(re.compile(r".*tile\..*"), mock_tiles)
         return page
 

--- a/umap/tests/integration/test_remote_data.py
+++ b/umap/tests/integration/test_remote_data.py
@@ -1,11 +1,15 @@
+import json
+import re
+from pathlib import Path
+
 from playwright.sync_api import expect
 
-from umap.models import Map
+from umap.models import DataLayer, Map
 
 from ..base import DataLayerFactory
 
 
-def test_dynamic_remote_data(page, live_server, tilelayer, map):
+def intercept_remote_data(page):
     data = [
         {
             "type": "FeatureCollection",
@@ -38,6 +42,13 @@ def test_dynamic_remote_data(page, live_server, tilelayer, map):
     def handle(route):
         route.fulfill(json=data.pop())
 
+    # Intercept the route to the proxy
+    page.route("https://remote.org/data.json", handle)
+    page.on("request", lambda *a, **k: print(a, k))
+
+
+def test_dynamic_remote_data(page, live_server, tilelayer, map):
+    intercept_remote_data(page)
     settings = {
         "remoteData": {
             "url": "https://remote.org/data.json",
@@ -55,8 +66,6 @@ def test_dynamic_remote_data(page, live_server, tilelayer, map):
     }
     map.save()
 
-    # Intercept the route to the proxy
-    page.route("https://remote.org/data.json", handle)
     page.goto(f"{live_server.url}{map.get_absolute_url()}")
 
     expect(page.get_by_role("tooltip", name="Point 1")).to_be_visible()
@@ -77,3 +86,50 @@ def test_dynamic_remote_data(page, live_server, tilelayer, map):
     # Map must not be dirty
     page.get_by_role("button", name="Edit").click()
     expect(page.locator(".edit-undo")).to_be_disabled()
+
+
+def test_create_remote_data_layer(page, live_server, tilelayer, settings):
+    settings.UMAP_ALLOW_ANONYMOUS = True
+    intercept_remote_data(page)
+    page.goto(f"{live_server.url}/en/map/new#6/11.2707/4.3375")
+    page.get_by_role("button", name="Manage layers").click()
+    page.get_by_role("button", name="Add a layer").click()
+    page.get_by_text("Remote data").click()
+    page.locator('.panel input[name="url"]').fill("https://remote.org/data.json")
+    # We have a setTimeout on each input to throttle, so wait for it
+    page.wait_for_timeout(300)
+    page.locator('select[name="format"]').select_option("geojson")
+    # with page.expect_response(re.compile("https://remote.org/data.json")):
+    page.get_by_role("button", name="Verify remote URL").click()
+    expect(page.locator(".leaflet-marker-icon")).to_have_count(1)
+    with page.expect_response(re.compile(".*/datalayer/create/.*")):
+        page.get_by_role("button", name="Save draft", exact=True).click()
+    datalayer = DataLayer.objects.last()
+    data = json.loads(Path(datalayer.geojson.path).read_text())
+    assert data == {
+        "_umap_options": {
+            "browsable": True,
+            "displayOnLoad": True,
+            "editMode": "advanced",
+            "fields": [
+                {
+                    "key": "name",
+                    "type": "String",
+                },
+                {
+                    "key": "description",
+                    "type": "Text",
+                },
+            ],
+            "id": str(datalayer.pk),
+            "inCaption": True,
+            "name": "Layer 1",
+            "rank": 0,
+            "remoteData": {
+                "format": "geojson",
+                "url": "https://remote.org/data.json",
+            },
+        },
+        "features": [],
+        "type": "FeatureCollection",
+    }


### PR DESCRIPTION
This is broken since the new FeatureManager I think.