### PR TITLE
chore: use array instead of object for filters

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -22,7 +22,7 @@ import * as Utils from '../utils.js'
 import { LineString, Point, Polygon } from './features.js'
 import Rules from '../rules.js'
 import { FeatureManager, FieldManager } from '../managers.js'
-import Filters from '../filters.js'
+import { Filters } from '../filters.js'
 
 export const LAYER_TYPES = [
   DefaultLayer,

--- a/umap/static/umap/js/modules/schema.js
+++ b/umap/static/umap/js/modules/schema.js
@@ -141,11 +141,11 @@ export const SCHEMA = {
     default: true,
   },
   filters: {
-    type: Object,
+    type: Array,
     impacts: ['ui'],
   },
   fields: {
-    type: Object,
+    type: Array,
   },
   fill: {
     type: Boolean,

--- a/umap/static/umap/js/modules/umap.js
+++ b/umap/static/umap/js/modules/umap.js
@@ -10,7 +10,7 @@ import {
 import Browser from './browser.js'
 import Caption from './caption.js'
 import { DataLayer } from './data/layer.js'
-import Filters from './filters.js'
+import { Filters, migrateLegacyFilters } from './filters.js'
 import { MutatingForm } from './form/builder.js'
 import { Formatter } from './formatter.js'
 import Help from './help.js'
@@ -49,6 +49,7 @@ export default class Umap {
   }
 
   async init(element, geojson) {
+    this.migrateLegacyProperties(geojson.properties)
     this.properties = Object.assign(
       {
         enableMarkerDraw: true,
@@ -729,7 +730,14 @@ export default class Umap {
     return this.properties.name || translate('Untitled map')
   }
 
+  migrateLegacyProperties(properties) {
+    if (migrateLegacyFilters(properties)) {
+      this._migrated = true
+    }
+  }
+
   setProperties(newProperties) {
+    this.migrateLegacyProperties(newProperties)
     for (const key of Object.keys(SCHEMA)) {
       if (newProperties[key] !== undefined) {
         this.properties[key] = newProperties[key]
@@ -1724,6 +1732,7 @@ export default class Umap {
     const fields = Object.keys(importedData.properties).map(
       (field) => `properties.${field}`
     )
+    this.filters.load()
     this.render(fields)
     this._leafletMap._setDefaultCenter()
   }

--- a/umap/tests/integration/test_filters.py
+++ b/umap/tests/integration/test_filters.py
@@ -97,10 +97,10 @@ DATALAYER_DATA3 = {
 
 def test_simple_facet_search(live_server, page, map):
     map.settings["properties"]["onLoadPanel"] = "datafilters"
-    map.settings["properties"]["filters"] = {
-        "mytype": {"label": "My type"},
-        "mynumber": {"label": "My number", "widget": "MinMax"},
-    }
+    map.settings["properties"]["filters"] = [
+        {"fieldKey": "mytype", "label": "My type"},
+        {"fieldKey": "mynumber", "label": "My number", "widget": "MinMax"},
+    ]
     map.settings["properties"]["fields"] = [
         {"key": "mytype", "type": "String"},
         {"key": "mynumber", "type": "Number"},
@@ -182,9 +182,9 @@ def test_simple_facet_search(live_server, page, map):
 
 def test_date_facet_search(live_server, page, map):
     map.settings["properties"]["onLoadPanel"] = "datafilters"
-    map.settings["properties"]["filters"] = {
-        "mydate": {"label": "Date filter", "widget": "MinMax"}
-    }
+    map.settings["properties"]["filters"] = [
+        {"fieldKey": "mydate", "label": "Date filter", "widget": "MinMax"}
+    ]
     map.settings["properties"]["fields"] = [{"key": "mydate", "type": "Date"}]
     map.save()
     DataLayerFactory(map=map, data=DATALAYER_DATA1)
@@ -204,7 +204,7 @@ def test_date_facet_search(live_server, page, map):
 def test_choice_with_empty_value(live_server, page, map):
     map.settings["properties"]["onLoadPanel"] = "datafilters"
     map.settings["properties"]["fields"] = [{"key": "mytype", "type": "String"}]
-    map.settings["properties"]["filters"] = {"mytype": {"label": "My type"}}
+    map.settings["properties"]["filters"] = [{"fieldKey": "mytype", "label": "My type"}]
     map.save()
     data = copy.deepcopy(DATALAYER_DATA1)
     data["features"][0]["properties"]["mytype"] = ""
@@ -221,9 +221,9 @@ def test_choice_with_empty_value(live_server, page, map):
 
 def test_number_with_zero_value(live_server, page, map):
     map.settings["properties"]["onLoadPanel"] = "datafilters"
-    map.settings["properties"]["filters"] = {
-        "mynumber": {"label": "Filter", "widget": "MinMax"}
-    }
+    map.settings["properties"]["filters"] = [
+        {"fieldKey": "mynumber", "label": "Filter", "widget": "MinMax"}
+    ]
     map.settings["properties"]["fields"] = [{"key": "mynumber", "type": "Number"}]
     map.save()
     data = copy.deepcopy(DATALAYER_DATA1)
@@ -241,10 +241,10 @@ def test_number_with_zero_value(live_server, page, map):
 
 def test_facets_search_are_persistent_when_closing_panel(live_server, page, map):
     map.settings["properties"]["onLoadPanel"] = "datafilters"
-    map.settings["properties"]["filters"] = {
-        "mytype": {"label": "My type"},
-        "mynumber": {"label": "My Number", "widget": "MinMax"},
-    }
+    map.settings["properties"]["filters"] = [
+        {"fieldKey": "mytype", "label": "My type"},
+        {"fieldKey": "mynumber", "label": "My Number", "widget": "MinMax"},
+    ]
     map.settings["properties"]["fields"] = [
         {"key": "mytype"},
         {"key": "mynumber", "type": "Number"},
@@ -317,20 +317,23 @@ def test_can_load_legacy_facetKey(live_server, page, openmap):
         page.get_by_role("button", name="Save", exact=True).click()
     saved = Map.objects.first()
     assert "facetKey" not in saved.settings["properties"]
-    assert saved.settings["properties"]["filters"] == {
-        "mydate": {
-            "label": "My Date",
-            "widget": "MinMax",
-        },
-        "mynumber": {
-            "label": "My Number",
-            "widget": "MinMax",
-        },
-        "mytype": {
+    assert saved.settings["properties"]["filters"] == [
+        {
+            "fieldKey": "mytype",
             "label": "My Type",
             "widget": "Radio",
         },
-    }
+        {
+            "fieldKey": "mynumber",
+            "label": "My Number",
+            "widget": "MinMax",
+        },
+        {
+            "fieldKey": "mydate",
+            "label": "My Date",
+            "widget": "MinMax",
+        },
+    ]
     assert saved.settings["properties"]["fields"] == [
         {"key": "mytype", "type": "String"},
         {"key": "mynumber", "type": "Number"},
@@ -344,10 +347,10 @@ def test_deleting_field_should_delete_filter(live_server, page, openmap, datalay
         {"key": "foobar", "type": "Number"},
         {"key": "description", "type": "Text"},
     ]
-    datalayer.settings["filters"] = {
-        "foobar": {"widget": "MinMax", "label": "Foo Bar"},
-        "name": {"widget": "Checkbox", "label": "Bar Foo"},
-    }
+    datalayer.settings["filters"] = [
+        {"fieldKey": "foobar", "widget": "MinMax", "label": "Foo Bar"},
+        {"fieldKey": "name", "widget": "Checkbox", "label": "Bar Foo"},
+    ]
     datalayer.save()
     page.goto(f"{live_server.url}{openmap.get_absolute_url()}?edit")
     page.get_by_role("button", name="Manage layers").click()
@@ -362,9 +365,9 @@ def test_deleting_field_should_delete_filter(live_server, page, openmap, datalay
         {"key": "name", "type": "String"},
         {"key": "description", "type": "Text"},
     ]
-    saved.settings["filters"] == {
-        "name": {"widget": "Checkbox", "label": "Bar Foo"},
-    }
+    saved.settings["filters"] == [
+        {"fieldKey": "name", "widget": "Checkbox", "label": "Bar Foo"},
+    ]
     page.locator(".edit-undo").click()
     with page.expect_response(re.compile(r".*/datalayer/update/")):
         page.get_by_role("button", name="Save").click()
@@ -374,10 +377,10 @@ def test_deleting_field_should_delete_filter(live_server, page, openmap, datalay
         {"key": "foobar", "type": "Number"},
         {"key": "description", "type": "Text"},
     ]
-    saved.settings["filters"] == {
-        "foobar": {"widget": "MinMax", "label": "Foo Bar"},
-        "name": {"widget": "Checkbox", "label": "Bar Foo"},
-    }
+    saved.settings["filters"] == [
+        {"fieldKey": "foobar", "widget": "MinMax", "label": "Foo Bar"},
+        {"fieldKey": "name", "widget": "Checkbox", "label": "Bar Foo"},
+    ]
 
 
 def test_deleting_field_from_map_should_delete_filter(live_server, page, openmap):
@@ -386,10 +389,10 @@ def test_deleting_field_from_map_should_delete_filter(live_server, page, openmap
         {"key": "foobar", "type": "Number"},
         {"key": "description", "type": "Text"},
     ]
-    openmap.settings["properties"]["filters"] = {
-        "foobar": {"widget": "MinMax", "label": "Foo Bar"},
-        "name": {"widget": "Checkbox", "label": "Bar Foo"},
-    }
+    openmap.settings["properties"]["filters"] = [
+        {"fieldKey": "foobar", "widget": "MinMax", "label": "Foo Bar"},
+        {"fieldKey": "name", "widget": "Checkbox", "label": "Bar Foo"},
+    ]
     openmap.save()
     page.goto(f"{live_server.url}{openmap.get_absolute_url()}?edit")
     page.get_by_role("button", name="Map advanced properties").click()
@@ -403,9 +406,9 @@ def test_deleting_field_from_map_should_delete_filter(live_server, page, openmap
         {"key": "name", "type": "String"},
         {"key": "description", "type": "Text"},
     ]
-    saved.settings["properties"]["filters"] == {
-        "name": {"widget": "Checkbox", "label": "Bar Foo"},
-    }
+    saved.settings["properties"]["filters"] == [
+        {"fieldKey": "name", "widget": "Checkbox", "label": "Bar Foo"},
+    ]
     page.locator(".edit-undo").click()
     with page.expect_response(re.compile(r"./update/settings/.*")):
         page.get_by_role("button", name="Save").click()
@@ -415,10 +418,10 @@ def test_deleting_field_from_map_should_delete_filter(live_server, page, openmap
         {"key": "foobar", "type": "Number"},
         {"key": "description", "type": "Text"},
     ]
-    saved.settings["properties"]["filters"] == {
-        "foobar": {"widget": "MinMax", "label": "Foo Bar"},
-        "name": {"widget": "Checkbox", "label": "Bar Foo"},
-    }
+    saved.settings["properties"]["filters"] == [
+        {"fieldKey": "foobar", "widget": "MinMax", "label": "Foo Bar"},
+        {"fieldKey": "name", "widget": "Checkbox", "label": "Bar Foo"},
+    ]
 
 
 def test_can_create_filter_from_new_field(live_server, page, openmap):
@@ -462,12 +465,13 @@ def test_can_create_filter_from_new_field(live_server, page, openmap):
         },
     ]
 
-    assert saved.settings["filters"] == {
-        "foobar": {
+    assert saved.settings["filters"] == [
+        {
+            "fieldKey": "foobar",
             "label": "Foo Bar",
             "widget": "Checkbox",
         },
-    }
+    ]
 
 
 def test_can_create_new_filter_on_map_from_panel(live_server, page, openmap):
@@ -494,9 +498,9 @@ def test_can_create_new_filter_on_map_from_panel(live_server, page, openmap):
     with page.expect_response(re.compile("./update/settings/.*")):
         page.get_by_role("button", name="Save", exact=True).click()
     saved = Map.objects.first()
-    assert saved.settings["properties"]["filters"] == {
-        "foobar": {"label": "Foo Bar", "widget": "Radio"}
-    }
+    assert saved.settings["properties"]["filters"] == [
+        {"fieldKey": "foobar", "label": "Foo Bar", "widget": "Radio"}
+    ]
 
 
 def test_can_create_new_filter_on_datalayer_from_panel(live_server, page, openmap):
@@ -513,8 +517,7 @@ def test_can_create_new_filter_on_datalayer_from_panel(live_server, page, openma
     page.get_by_role("button", name="Manage filters").click()
     page.get_by_text("Calque 1 (single layer)").click()
     page.get_by_role("button", name="Add filter").click()
-    expect(page.get_by_label("Apply filter to")).to_have_value(f"map:{openmap.pk}")
-    page.get_by_label("Apply filter to").select_option(f"layer:{datalayer.pk}")
+    expect(page.get_by_label("Apply filter to")).to_have_value(f"layer:{datalayer.pk}")
     page.get_by_label("Filter on").select_option("mynumber")
     page.get_by_role("textbox", name="Human readable name of the").fill("Foo Bar")
     page.wait_for_timeout(300)
@@ -526,9 +529,9 @@ def test_can_create_new_filter_on_datalayer_from_panel(live_server, page, openma
     with page.expect_response(re.compile("./datalayer/update/.*")):
         page.get_by_role("button", name="Save", exact=True).click()
     saved = DataLayer.objects.first()
-    assert saved.settings["filters"] == {
-        "mynumber": {"label": "Foo Bar", "widget": "Radio"}
-    }
+    assert saved.settings["filters"] == [
+        {"fieldKey": "mynumber", "label": "Foo Bar", "widget": "Radio"}
+    ]
 
 
 def test_can_edit_filter_from_panel(live_server, page, openmap):
@@ -537,10 +540,10 @@ def test_can_edit_filter_from_panel(live_server, page, openmap):
         {"key": "foobar", "type": "Number"},
         {"key": "description", "type": "Text"},
     ]
-    openmap.settings["properties"]["filters"] = {
-        "foobar": {"widget": "MinMax", "label": "Foo Bar"},
-        "name": {"widget": "Checkbox", "label": "Bar Foo"},
-    }
+    openmap.settings["properties"]["filters"] = [
+        {"fieldKey": "foobar", "widget": "MinMax", "label": "Foo Bar"},
+        {"fieldKey": "name", "widget": "Checkbox", "label": "Bar Foo"},
+    ]
     openmap.save()
     page.goto(
         f"{live_server.url}{openmap.get_absolute_url()}?edit&onLoadPanel=datafilters"

--- a/umap/tests/integration/test_tableeditor.py
+++ b/umap/tests/integration/test_tableeditor.py
@@ -235,6 +235,6 @@ def test_add_filter_on_map_field(live_server, openmap, page):
     with page.expect_response(re.compile("./update/settings/.*")):
         page.get_by_role("button", name="Save").click()
     saved = Map.objects.first()
-    assert saved.settings["properties"]["filters"] == {
-        "mynumber": {"widget": "MinMax", "label": "My Fun Filter"}
-    }
+    assert saved.settings["properties"]["filters"] == [
+        {"fieldKey": "mynumber", "widget": "MinMax", "label": "My Fun Filter"}
+    ]


### PR DESCRIPTION
Otherwise, we lose the order when saving/reloading from backend.