### PR TITLE
fix: permanent credit should have a background color by default

### DIFF
--- a/umap/static/umap/js/modules/rendering/controls.js
+++ b/umap/static/umap/js/modules/rendering/controls.js
@@ -112,7 +112,9 @@ export const PermanentCreditsControl = Control.extend({
     const container = Utils.loadTemplate(
       `<div class="umap-permanent-credits-container text">${Utils.toHTML(map.options.permanentCredit)}</div>`
     )
-    const background = map.options.permanentCreditBackground ? '#FFFFFFB0' : ''
+    const background = map._umap.getProperty('permanentCreditBackground')
+      ? '#FFFFFFB0'
+      : ''
     container.style.backgroundColor = background
     return container
   },


### PR DESCRIPTION
We need to read the default value from the schema, thus using the getProprety method instead of reading the options directly