### PR TITLE
fix: fix "filter data" button in contextmenu

### DIFF
--- a/umap/static/umap/js/modules/browser.js
+++ b/umap/static/umap/js/modules/browser.js
@@ -97,8 +97,8 @@ export default class Browser {
   }
 
   toggleBadge() {
-    Utils.toggleBadge(this.filtersTitle, this.hasFilters())
-    Utils.toggleBadge('.umap-control-browse', this.hasFilters())
+    Utils.toggleBadge(this.filtersTitle, this.hasActiveFilters())
+    Utils.toggleBadge('.umap-control-browse', this.hasActiveFilters())
   }
 
   onFormChange() {
@@ -118,8 +118,8 @@ export default class Browser {
     return !!document.querySelector('.on .umap-browser')
   }
 
-  hasFilters() {
-    return !!this.options.filter || this._umap.hasFilters()
+  hasActiveFilters() {
+    return !!this.options.filter || this._umap.hasActiveFilters()
   }
 
   onMoveEnd() {

--- a/umap/static/umap/js/modules/rendering/controls.js
+++ b/umap/static/umap/js/modules/rendering/controls.js
@@ -166,7 +166,7 @@ export const DataLayersControl = BaseButton.extend({
   },
 
   afterAdd: function (container) {
-    Utils.toggleBadge(container, this._umap.browser?.hasFilters())
+    Utils.toggleBadge(container, this._umap.browser?.hasActiveFilters())
   },
 
   onClick: function () {

--- a/umap/static/umap/js/modules/umap.js
+++ b/umap/static/umap/js/modules/umap.js
@@ -389,6 +389,10 @@ export default class Umap {
   }
 
   hasFilters() {
+    return this.filters.size || this.datalayers.active().some((d) => d.filters.size)
+  }
+
+  hasActiveFilters() {
     return (
       this.filters.isActive() ||
       this.datalayers.active().some((d) => d.filters.isActive())


### PR DESCRIPTION
There was a confusion between "hasFilters", which
means filters has been created by the map administrator, and "hasActiveFilters", which means those filters are currently used by the user seeing the map