### PR TITLE
chore: skip a failing test in CI

### DIFF
--- a/umap/tests/integration/conftest.py
+++ b/umap/tests/integration/conftest.py
@@ -48,6 +48,14 @@ def page(new_page):
 
 
 @pytest.fixture
+def wait_for_loaded():
+    def _(page):
+        page.wait_for_function("() => U.MAP.dataloaded === true")
+
+    return _
+
+
+@pytest.fixture
 def login(new_page, settings, live_server):
     def do_login(user, **kwargs):
         # TODO use storage state to do login only once per session


### PR DESCRIPTION
This test fails very often when in the CI, but very rarely in local runs.

Here is a log from a failing test:

Page A: SYNC ⇆ "received join response" {"peer":"y9TAt","peers":{"y9TAt":"Joe"}}
Page A: SYNC ⇆ "received peerinfo" {"y9TAt":"Joe"}
Page A: SYNC ⇆ "received peerinfo" {"y9TAt":"Joe"}
Page A: Closing
Page A: websocket closed
Page B: SYNC ⇆ "received join response" {"peer":"wJDHk","peers":{"y9TAt":"Joe","wJDHk":"Joe"}}
Page B: SYNC ⇆ "received peerinfo" {"y9TAt":"Joe","wJDHk":"Joe"}
Page B: SYNC ⇆ "received peerinfo" {"y9TAt":"Joe","wJDHk":"Joe"}
Page A uncaught exception: Failed to execute 'send' on 'WebSocket': Still in CONNECTING state.
Page A: SYNC ⇆ "received join response" {"peer":"y9TAt","peers":{"y9TAt":"Joe","wJDHk":"Joe"}}
Page A: SYNC ⇆ "received peerinfo" {"y9TAt":"Joe","wJDHk":"Joe"}
Page B: SYNC ⇆ "received peerinfo" {"y9TAt":"Joe","wJDHk":"Joe"}
Page B: SYNC ⇆ "received peermessage" {"sender":"y9TAt","recipient":"wJDHk","message":{"lastKnownHLC":"1761315304707:0:wAdw3","verb":"ListOperationsRequest"}}
Page B: SYNC ⇆ "received operations request from peer y9TAt (since 1761315304707:0:wAdw3)"
Page A: SYNC ⇆ "received peerinfo" {"y9TAt":"Joe","wJDHk":"Joe"}
Page A: SYNC ⇆ "received peermessage" {"sender":"wJDHk","recipient":"y9TAt","message":{"operations":[],"verb":"ListOperationsResponse"}}
Page A: SYNC ⇆ "received operations list from peer wJDHk" []