### PR TITLE
fix: reset fields before filters in raw uMap import

### DIFF
--- a/umap/static/umap/js/modules/umap.js
+++ b/umap/static/umap/js/modules/umap.js
@@ -1729,6 +1729,7 @@ export default class Umap {
     const fields = Object.keys(importedData.properties).map(
       (field) => `properties.${field}`
     )
+    this.fields.pull()
     this.filters.load()
     this.render(fields)
     this._leafletMap._setDefaultCenter()


### PR DESCRIPTION
fix #3059