### PR TITLE
fix: add help text for Enum input

### DIFF
--- a/umap/static/umap/js/modules/data/features.js
+++ b/umap/static/umap/js/modules/data/features.js
@@ -271,6 +271,8 @@ class Feature {
         options.handler = 'DateTimeInput'
       } else if (field.TYPE === 'Boolean') {
         options.handler = 'Switch'
+      } else if (field.TYPE === 'Enum') {
+        options.helpText = translate('Comma separated list of values')
       }
       properties.push([`properties.${field.key}`, options])
     }


### PR DESCRIPTION
Make clearer what this input is about.
In a later move, we'd like to have a dedicated UI/widget.

fix #3055