### PR TITLE
fix: do not create default fields for remote data layers

### DIFF
--- a/umap/static/umap/js/modules/data/layer.js
+++ b/umap/static/umap/js/modules/data/layer.js
@@ -86,9 +86,6 @@ export class DataLayer {
     this.permissions = new DataLayerPermissions(this._umap, this)
 
     this._needsFetch = this.createdOnServer || this.isRemoteLayer()
-    if (!this._needsFetch && !this._umap.fields.size) {
-      this.properties.fields = getDefaultFields()
-    }
     this.fields = new Fields(this, this._umap.dialog)
     this.filters = new Filters(this, this._umap)
     this.rules = new Rules(umap, this)
@@ -447,6 +444,10 @@ export class DataLayer {
     this._umap.featuresIndex[feature.getSlug()] = feature
     // TODO: quid for remote data ?
     this.inferFields(feature)
+    if (!this.fields.size && !this._umap.fields.size) {
+      this.properties.fields = getDefaultFields()
+      this.fields.pull()
+    }
     try {
       this.showFeature(feature)
     } catch (error) {

--- a/umap/tests/integration/test_remote_data.py
+++ b/umap/tests/integration/test_remote_data.py
@@ -16,7 +16,7 @@ def intercept_remote_data(page):
             "features": [
                 {
                     "type": "Feature",
-                    "properties": {"name": "Point 2"},
+                    "properties": {"name": "Point 2", "foobar": "bla"},
                     "geometry": {
                         "type": "Point",
                         "coordinates": [4.3375, 11.2707],
@@ -29,7 +29,7 @@ def intercept_remote_data(page):
             "features": [
                 {
                     "type": "Feature",
-                    "properties": {"name": "Point 1"},
+                    "properties": {"name": "Point 1", "foobar": "baz"},
                     "geometry": {
                         "type": "Point",
                         "coordinates": [4.3375, 12.2707],
@@ -117,8 +117,8 @@ def test_create_remote_data_layer(page, live_server, tilelayer, settings):
                     "type": "String",
                 },
                 {
-                    "key": "description",
-                    "type": "Text",
+                    "key": "foobar",
+                    "type": "String",
                 },
             ],
             "id": str(datalayer.pk),


### PR DESCRIPTION
The issue appeared when creating a new layer and setting it as remote data. Now we only create default fields when adding a feature to the layer, and if the layer has no fields yet, and neither the map.

fix #3082