### PR TITLE
feat: add osm_type and osm_id properties for OSM data

### DIFF
--- a/docs-users/fr/support/faq.md
+++ b/docs-users/fr/support/faq.md
@@ -94,6 +94,7 @@ Toute propriété de l'élément sera disponible, ainsi que:
 - `{layer}` → le nom du calque de l'élément
 - `{zoom}` → le zoom actuel de la carte
 - `{id}` → identifiant unique d'un élément
+- `{osm_type}`, `{osm_id}` → type (node, way, relation) et identifiant unique d'un élément, quand les données viennent d'OpenStreetMap
 
 ### Variables disponibles dans les URL de données distantes:
 

--- a/docs-users/support/faq.md
+++ b/docs-users/support/faq.md
@@ -94,6 +94,7 @@ Any property of the feature will be available, plus:
 - `{layer}` → the name of the feature's layer
 - `{zoom}` → the current map zoom
 - `{id}` → the unique feature id
+- `{osm_type}`, `{osm_id}` → the unique feature type (node, way, relation) and id, when data comes from OpenStreetMap
 
 ### Available variables in URL for remote data:
 

--- a/umap/static/umap/js/modules/formatter.js
+++ b/umap/static/umap/js/modules/formatter.js
@@ -71,7 +71,15 @@ export class Formatter {
     } catch (e) {
       src = this.toDom(str)
     }
-    return osmtogeojson(src, { flatProperties: true })
+    const data = osmtogeojson(src, { flatProperties: true })
+    // FIXME: make a PR to osmtogeojson when it's more active
+    // cf https://github.com/umap-project/umap/issues/3072
+    for (const feature of data.features || []) {
+      const [osm_type, osm_id] = feature.properties.id.split('/')
+      feature.properties.osm_id = osm_id
+      feature.properties.osm_type = osm_type
+    }
+    return data
   }
 
   fromCSV(str, callback) {


### PR DESCRIPTION
The data is parsed by osmtogeojson, which creates an "id" property consisting in "osm_type/osm_id", which can limit the ability to use the id itself in some situations (eg. when calling osm.org/edit?node=xxxx).

fix #3072