### PR TITLE
fix: do not fail when classified colors are named colors

### DIFF
--- a/umap/static/umap/js/modules/domutils.js
+++ b/umap/static/umap/js/modules/domutils.js
@@ -82,6 +82,10 @@ export const hexToRGB = (hex) => {
     .match(/.{2}/g)
     .map((x) => Number.parseInt(x, 16))
 }
+export const colorToRGB = (color) => {
+  if (!color.startsWith('#')) color = colorNameToHex(color)
+  return hexToRGB(color)
+}
 
 const CACHE_CONTRAST = {}
 export const contrastedColor = (el, bgcolor) => {

--- a/umap/static/umap/js/modules/rendering/layers/classified.js
+++ b/umap/static/umap/js/modules/rendering/layers/classified.js
@@ -80,7 +80,7 @@ const ClassifiedMixin = {
     const ul = Utils.loadTemplate('<ul></ul>')
     const items = this.getLegendItems()
     for (const [color, label] of items) {
-      const rgbColor = DOMUtils.hexToRGB(color)
+      const rgbColor = DOMUtils.colorToRGB(color)
       const opacity = this.datalayer.getOption('fillOpacity')
       const bgColor = `rgba(${rgbColor.join(',')}, ${opacity})`
       const li = Utils.loadTemplate(`


### PR DESCRIPTION
We were using named color as if they were hex color.