### PR TITLE
fix: be more defensive when computing handleLimitBounds

### DIFF
--- a/umap/static/umap/js/modules/rendering/map.js
+++ b/umap/static/umap/js/modules/rendering/map.js
@@ -343,10 +343,10 @@ export const LeafletMap = BaseMap.extend({
   },
 
   handleLimitBounds: function () {
-    const south = Number.parseFloat(this.options.limitBounds.south)
-    const west = Number.parseFloat(this.options.limitBounds.west)
-    const north = Number.parseFloat(this.options.limitBounds.north)
-    const east = Number.parseFloat(this.options.limitBounds.east)
+    const south = Number.parseFloat(this.options.limitBounds?.south)
+    const west = Number.parseFloat(this.options.limitBounds?.west)
+    const north = Number.parseFloat(this.options.limitBounds?.north)
+    const east = Number.parseFloat(this.options.limitBounds?.east)
     if (
       !Number.isNaN(south) &&
       !Number.isNaN(west) &&


### PR DESCRIPTION
Some old maps seem to have limitBounds=null