### PR TITLE
chore: only install chromium headless in CI

### DIFF
--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -46,7 +46,7 @@ jobs:
           sudo apt update
           sudo apt install libgdal-dev
           python -m pip install --upgrade pip
-          make develop
+          make ci
           npm install mocha
       - name: run tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ develop: ## Install the test and dev dependencies
 	python3 -m pip install -e .[test,dev,sync,s3]
 	playwright install
 
+.PHONY: ci
+ci: ## Install the test and dev dependencies for ci
+	python3 -m pip install -e .[test,dev,sync,s3]
+	playwright install chromium-headless-shell
+
 .PHONY: format
 format: ## Format the code and templates files
 	-djlint umap/templates --reformat


### PR DESCRIPTION
A bit less to download and then also a bit less time to run ?