### PR TITLE
fix: do not try to sync datalayer objects

### DIFF
--- a/umap/static/umap/js/modules/data/features.js
+++ b/umap/static/umap/js/modules/data/features.js
@@ -244,8 +244,10 @@ class Feature {
       </div>
     `)
 
+    // No need to sync the datalayer key, given we already do a delete/upsert when
+    // it changes.
     let builder = new MutatingForm(this, [
-      ['datalayer', { handler: 'EditableDataLayerSwitcher' }],
+      ['datalayer', { handler: 'EditableDataLayerSwitcher', sync: false }],
     ])
     // removeLayer step will close the edit panel, let's reopen it
     builder.on('set', () => this.edit(event))

--- a/umap/static/umap/js/modules/form/builder.js
+++ b/umap/static/umap/js/modules/form/builder.js
@@ -56,30 +56,31 @@ export class Form extends Utils.WithEvents {
     return this.helpers[field]
   }
 
-  getter(field) {
-    const path = field.split('.')
+  getter(helper) {
+    const path = helper.field.split('.')
     let value = this.obj
     for (const sub of path) {
       try {
         value = value[sub]
       } catch {
-        console.debug(field)
+        console.debug(helper.field)
       }
     }
     return value
   }
 
-  setter(field, value) {
+  setter(helper, value) {
     if ('setter' in this.obj) {
-      this.obj.setter(field, value)
+      this.obj.setter(helper.field, value)
     } else {
-      Utils.setObjectValue(this.obj, field, value)
+      Utils.setObjectValue(this.obj, helper.field, value)
     }
   }
 
   restoreField(field) {
-    const initial = this.helpers[field].initial
-    this.setter(field, initial)
+    const helper = this.helpers[field]
+    const initial = helper.initial
+    this.setter(helper.field, initial)
   }
 
   getName(field) {
@@ -180,21 +181,21 @@ export class MutatingForm extends Form {
     }
   }
 
-  setter(field, value) {
-    const oldValue = this.getter(field)
-    super.setter(field, value)
+  setter(helper, value) {
+    const oldValue = this.getter(helper)
+    super.setter(helper, value)
     if ('render' in this.obj) {
-      this.obj.render([field], this)
+      this.obj.render([helper.field], this)
     }
-    if ('sync' in this.obj) {
-      this.obj.sync.update(field, value, oldValue)
+    if ('sync' in this.obj && helper.properties.sync !== false) {
+      this.obj.sync.update(helper.field, value, oldValue)
     }
   }
 
   getTemplate(helper) {
     let template
     if (helper.properties.inheritable) {
-      const extraClassName = this.getter(helper.field) === undefined ? ' undefined' : ''
+      const extraClassName = this.getter(helper) === undefined ? ' undefined' : ''
       template = `
         <div class="umap-field-${helper.name} formbox inheritable${extraClassName}">
           <div class="header" data-ref=header>

--- a/umap/static/umap/js/modules/form/fields.js
+++ b/umap/static/umap/js/modules/form/fields.js
@@ -87,7 +87,7 @@ Fields.Base = class {
     const path = this.field.split('.')
     const key = path[path.length - 1]
     if (!this.properties.inheritable) {
-      value = this.builder.getter(this.field)
+      value = this.builder.getter(this)
     } else {
       value = this.obj.getOption(key)
     }
@@ -109,7 +109,7 @@ Fields.Base = class {
   }
 
   set() {
-    this.builder.setter(this.field, this.toJS())
+    this.builder.setter(this, this.toJS())
   }
 
   getLabelTemplate() {
@@ -644,7 +644,7 @@ const BaseDataLayerSwitcher = class extends Fields.Select {
 
   set() {
     this.builder._umap.lastUsedDataLayer = this.toJS()
-    this.builder.setter(this.field, this.toJS())
+    this.builder.setter(this, this.toJS())
   }
 }
 
@@ -762,7 +762,7 @@ Fields.IconUrl = class extends Fields.BlurInput {
     // in the super method, maybe it's useless for all fields.
     const path = this.field.split('.')
     const key = path[path.length - 1]
-    return this.builder.getter(this.field)
+    return this.builder.getter(this)
   }
 
   getTemplate() {


### PR DESCRIPTION
This issue appeared when changing the datalayer of a feature. But given we do a delete/upsert, we don't need to sync the `datalayer` key itself.