### PR TITLE
chore: bump social-auth-django and social-auth-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ dependencies = [
   "requests==2.32.5",
   "rcssmin==1.2.2",
   "rjsmin==1.2.5",
-  "social-auth-core==4.8.1",
-  "social-auth-app-django==5.6.0",
+  "social-auth-core==4.8.3",
+  "social-auth-app-django==5.7.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
dependabot seems to have hard time updating them…