### PR TITLE
fix: do not assign Field method to Rule

### DIFF
--- a/umap/static/umap/js/modules/rules.js
+++ b/umap/static/umap/js/modules/rules.js
@@ -69,7 +69,7 @@ class Rule {
     }
     // TODO: deal with legacy rules on non typed fields
     else {
-      this.cast = this.field.parse
+      this.cast = (value) => this.field.parse(value)
       if (
         // Special cases where we want to be lousy when checking isNaN without
         // coercing to a Number first because we handle multiple types.

--- a/umap/tests/fixtures/test_upload_data_with_enum.umap
+++ b/umap/tests/fixtures/test_upload_data_with_enum.umap
@@ -1,0 +1,151 @@
+{
+  "type": "umap",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [
+      2.243270874023438,
+      47.61958693358351
+    ]
+  },
+  "properties": {
+    "name": "Map with Enum",
+    "tags": [
+      "tourism",
+      "cycling"
+    ],
+    "zoom": 10,
+    "center": {
+      "lat": 47.61958693358351,
+      "lng": 2.243270874023438
+    }
+  },
+  "layers": [
+    {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "coordinates": [
+              4.492482,
+              47.539039
+            ],
+            "type": "Point"
+          },
+          "properties": {
+            "name": "I'm a foo",
+            "toilets": true,
+            "features": "foo"
+          },
+          "id": "tAuzC"
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              3.496243506779722,
+              47.86537360504818,
+              133.827948907274
+            ]
+          },
+          "properties": {
+            "name": "I'm a bar",
+            "toilets": false,
+            "features": "bar"
+          },
+          "id": "tAuzD"
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              0.7150469999999999,
+              49.23001199999999,
+              0
+            ]
+          },
+          "properties": {
+            "name": "I'm another foo",
+            "toilets": false,
+            "features": "foo"
+          },
+          "id": "tAuzE"
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "coordinates": [
+              4.931327,
+              48.022719
+            ],
+            "type": "Point"
+          },
+          "properties": {
+            "name": "I've no features"
+          },
+          "id": "RTaA8"
+        }
+      ],
+      "_umap_options": {
+        "name": "van.spots",
+        "rank": 0,
+        "color": "DodgerBlue",
+        "rules": [
+          {
+            "name": "has toilets",
+            "condition": "toilets=true",
+            "properties": {
+              "color": "green"
+            }
+          },
+          {
+            "name": "has foo",
+            "condition": "features=foo",
+            "properties": {
+              "color": "MediumOrchid"
+            }
+          },
+          {
+            "name": "has bar",
+            "condition": "features=bar",
+            "properties": {
+              "color": "red"
+            }
+          }
+        ],
+        "fields": [
+          {
+            "key": "name",
+            "type": "String"
+          },
+          {
+            "key": "toilets",
+            "type": "Boolean"
+          },
+          {
+            "key": "features",
+            "type": "Enum"
+          }
+        ],
+        "weight": 12,
+        "filters": [
+          {
+            "widget": "Switch",
+            "fieldKey": "toilets"
+          },
+          {
+            "widget": "Checkbox",
+            "fieldKey": "features"
+          }
+        ],
+        "editMode": "advanced",
+        "browsable": true,
+        "iconClass": "LargeCircle",
+        "inCaption": true,
+        "remoteData": {}
+      }
+    }
+  ]
+}

--- a/umap/tests/integration/test_import.py
+++ b/umap/tests/integration/test_import.py
@@ -1123,3 +1123,17 @@ def test_umap_import_with_iconurl(live_server, tilelayer, page):
             'img[src="https://umap.incubateur.anct.gouv.fr/uploads/pictogram/car-24.png"]'
         )
     ).to_have_count(2)
+
+
+def test_umap_import_with_enum_and_filter(live_server, tilelayer, page):
+    page.goto(f"{live_server.url}/map/new/")
+    page.get_by_title("Import data").click()
+    file_input = page.locator("input[type='file']")
+    with page.expect_file_chooser() as fc_info:
+        file_input.click()
+    file_chooser = fc_info.value
+    path = Path(__file__).parent.parent / "fixtures/test_upload_data_with_enum.umap"
+    file_chooser.set_files(path)
+    page.get_by_role("button", name="Import data", exact=True).click()
+    markers = page.locator(".umap-large-circle-icon")
+    expect(markers).to_have_count(4)


### PR DESCRIPTION
Doing so, `parse` wall called with the wrong `this`, which ended up in an infinite loop, as it was then calling `this.cast` on the Rule itself, which has been set to `parse`…

fix #3179