### PR TITLE
Add docker CI

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,44 @@
+name: Build and Push Docker Image
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version
+        id: vars
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            umap/umap:${{ steps.vars.outputs.version }}
+            ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.version }}


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automatically build and publish Docker images to Docker Hub whenever a new release is published.

## Motivation
Currently, Docker images are apparently published manually and may lag behind official releases. This automation ensures Docker images stay in sync with tagged releases.

## Details
- Trigger: release.published
- Tags Docker images using the release version
- Pushes to Docker Hub (umap/umap)
- Also publishes to GitHub Container Registry (ghcr.io) using the built-in GITHUB_TOKEN (no extra secrets required)

## Requirements
Repository secrets must be configured:
- DOCKERHUB_USERNAME
- DOCKERHUB_TOKEN

## Optional
We can also publish a `latest` tag if desired.

## Note
I could not test this thoroughly to make sure it actually works to push to docker hub. Let me know if I should revise or test in some specific way.