### PR TITLE
feat: support JOSM syntax for url_template

### DIFF
--- a/umap/models.py
+++ b/umap/models.py
@@ -119,7 +119,7 @@ class Licence(NamedModel):
 
 class TileLayer(NamedModel):
     url_template = models.CharField(
-        max_length=400, help_text=_("URL template using OSM tile format")
+        max_length=400, help_text=_("URL template using OSM or JOSM tile format")
     )
     minZoom = models.IntegerField(default=0)
     maxZoom = models.IntegerField(default=18)

--- a/umap/static/umap/js/modules/rendering/map.js
+++ b/umap/static/umap/js/modules/rendering/map.js
@@ -158,7 +158,10 @@ const ManageTilelayerMixin = {
     if (this._controls) this._controls.tilelayers.setLayers()
   },
 
-  createTileLayer: (tilelayer) => new TileLayer(tilelayer.url_template, tilelayer),
+  createTileLayer: function (tilelayer) {
+    const url = Utils.convertJOSM(tilelayer);
+    return new TileLayer(url, tilelayer);
+  },
 
   selectTileLayer: function (tilelayer) {
     if (tilelayer === this.selectedTilelayer) {

--- a/umap/static/umap/js/modules/utils.js
+++ b/umap/static/umap/js/modules/utils.js
@@ -739,3 +739,44 @@ export const asciiTree = (layers) => {
     console.groupEnd()
   }
 }
+
+/**
+ * Handle some JOSM conventions in the URL template.
+ *
+ * This modifies `tilelayer` in place to update the properties
+ * `url_template`, `tms`, `subdomains`, `zoomReverse`, `maxZoom` and
+ * `zoomOffset` according to possible JOSM template parameters as
+ * described in
+ * https://josm.openstreetmap.de/wiki/Maps#TileMapServicesTMS
+ *
+ * @param {tilelayer} Tile layer parameters.
+ * @returns Updated URL
+ */
+export function convertJOSM(tilelayer) {
+  let url = tilelayer.url_template;
+  // Handle {switch:1,2,3}
+  url = url.replace(/\{switch:([^}]+)\}/, (_match, p1) => {
+    if (p1)
+      tilelayer.subdomains = p1.split(",");
+    return "{s}";
+  });
+  // Handle {-y} for inverted Y-axis
+  url = url.replace(/\{-y\}/, () => {
+    tilelayer.tms = true;
+    return "{y}";
+  });
+  // Handle zoom offsets and reversed zooms
+  url = url.replace(/\{(?:(\d+)-)?zoom([+-]\d+)?\}/, (_match, p1, p2) => {
+    if (p1 !== undefined) {
+      tilelayer.zoomReverse = true;
+      tilelayer.maxZoom = parseInt(m[1]);
+    }
+    if (p2 !== undefined) {
+      tilelayer.zoomOffset = parseInt(m[2]);
+    }
+    return "{z}";
+  });
+  // Not supported: {!z}, {quad}, {apikey} (that's probably okay)
+  tilelayer.url_template = url;
+  return url;
+}

--- a/umap/tests/integration/test_tilelayer.py
+++ b/umap/tests/integration/test_tilelayer.py
@@ -66,7 +66,7 @@ def tilelayers():
     TileLayerFactory(
         rank=11,
         name="OSM OpenTopoMap",
-        url_template="https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png",
+        url_template="https://{switch:a,b,c}.tile.opentopomap.org/{zoom}/{x}/{y}.png",
     )
 
 


### PR DESCRIPTION
Fixes: #3292

This allows the use of `{zoom}` and its variants (e.g. `{19-zoom+2}`), `{-y}` for reversed y-coordinates, and `{switch:a,b,c}` for multiple servers.

Basically to allow people to directly use map sources from this excellent list: https://josm.openstreetmap.de/wiki/Maps

(of course, we could do something even more interesting like parsing sources directly from the XML at https://josm.openstreetmap.de/maps)