### PR TITLE
fix(tests): allow testing without postgres superuser

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -71,7 +71,9 @@ sudo -u postgres psql test_umap -c "CREATE EXTENSION postgis"
 
 You will also need to run the tests with `pytest -n 0` to prevent
 `pytest` from running multiple processes, each of which requires its
-own database.
+own database.  Alternately, you can manually create a database for
+each process as shown above - the databases will be named
+`test_umap_gw0` through `test_umap_gw3`.
 
 The Django configuration for testing is **not** in
 `umap/settings/local.py` but in `umap/tests/settings.py`.  If you need

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -52,11 +52,35 @@ This will run JavaScript and Python unittests + Playwright integration tests
 
 #### Python unit tests
 
+Python unit tests require you to have a PostgreSQL server with either:
+
+1. Super-user access (the `postgres` user) with password
+   authentication, as you might have in a Docker container.  This is
+   how the GitHub CI tests run.
+2. A `test_umap` database already created with PostGIS enabled.
+
+If you are running PostgreSQL on a Debian installation with peer
+authentication (meaning, your PostgreSQL username is the same as your
+Unix username), you will need to create the test database before
+running tests, like this:
+
+```bash
+sudo -u postgres createdb test_umap -O $USER
+sudo -u postgres psql test_umap -c "CREATE EXTENSION postgis"
+```
+
+The Django configuration for testing is **not** in
+`umap/settings/local.py` but in `umap/tests/settings.py`.  If you need
+to configure a specific remote PostgreSQL server for testing, you can
+set `DATABASES` in this file.
+
+Now you can run the unit tests:
+
 ```bash
 pytest . --ignore umap/tests/integration
 ```
 
-By default, the tests are run in parallel to reduce the time taken to run them. You can run them in serial mode by using the `-n1` option.
+By default, the tests are run in parallel to reduce the time taken to run them. You can run them in serial mode by using the `-n 0` option.
 
 If you only want to run one test, you can add `-k specific-test-name` to the command line.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,6 +69,10 @@ sudo -u postgres createdb test_umap -O $USER
 sudo -u postgres psql test_umap -c "CREATE EXTENSION postgis"
 ```
 
+You will also need to run the tests with `pytest -n 0` to prevent
+`pytest` from running multiple processes, each of which requires its
+own database.
+
 The Django configuration for testing is **not** in
 `umap/settings/local.py` but in `umap/tests/settings.py`.  If you need
 to configure a specific remote PostgreSQL server for testing, you can

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,3 +110,7 @@ line_break_after_multiline_tag=true
 [lint]
 # Disable autoremove of unused import.
 unfixable = ["F401"]
+
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "umap.settings.local"
+addopts = "--pdbcls=IPython.terminal.debugger:Pdb --no-migrations --numprocesses auto --reuse-db"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-DJANGO_SETTINGS_MODULE=umap.tests.settings
-addopts = --pdbcls=IPython.terminal.debugger:Pdb --no-migrations --numprocesses auto

--- a/umap/tests/conftest.py
+++ b/umap/tests/conftest.py
@@ -33,7 +33,8 @@ def pytest_runtest_teardown():
     shutil.rmtree(TMP_ROOT, ignore_errors=True)
     cache.clear()
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def django_db_modify_db_settings():
     # Force xdist to reuse the same database to avoid requiring superuser
     pass

--- a/umap/tests/conftest.py
+++ b/umap/tests/conftest.py
@@ -33,6 +33,11 @@ def pytest_runtest_teardown():
     shutil.rmtree(TMP_ROOT, ignore_errors=True)
     cache.clear()
 
+@pytest.fixture(scope='session')
+def django_db_modify_db_settings():
+    # Force xdist to reuse the same database to avoid requiring superuser
+    pass
+
 
 @pytest.fixture
 def team():

--- a/umap/tests/conftest.py
+++ b/umap/tests/conftest.py
@@ -34,12 +34,6 @@ def pytest_runtest_teardown():
     cache.clear()
 
 
-@pytest.fixture(scope="session")
-def django_db_modify_db_settings():
-    # Force xdist to reuse the same database to avoid requiring superuser
-    pass
-
-
 @pytest.fixture
 def team():
     return TeamFactory()


### PR DESCRIPTION
Fixes: #3294

This makes the default behaviour to reuse the `test_umap` database, ~and to use it for all subprocesses with `pytest-xdist`~ (unfotunately that doesn't work).  The contributing documentation has also been updated to describe how to set up PostgreSQL on a Debian (or other GNU/Linux distribution using peer authentication) to allow tests to run.

Also the pytest configuration is in `pyproject.toml` where it's easy to find :smile: 