### PR TITLE
fix: workaround memory leak in GeoDjango/GEOS

### DIFF
--- a/umap/middleware.py
+++ b/umap/middleware.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import BACKEND_SESSION_KEY
+from django.contrib.gis.geos.prototypes import io as geos_io
 from django.core.exceptions import MiddlewareNotUsed
 from django.http import (
     HttpResponseForbidden,
@@ -8,6 +9,28 @@ from django.http import (
 )
 from django.urls import reverse
 from django.utils.translation import gettext as _
+
+
+def geos_thread_cleanup(get_response):
+    """Work around Django #29878.
+
+    Under ASGI, Django runs each sync request in a worker thread that is torn
+    down afterwards. GEOS keeps thread-local WKB/WKT readers/writers; when the
+    thread is destroyed, their destructors re-create a GEOSContextHandle while
+    Python is clearing thread-local storage, and that handle is never freed —
+    one leaked handle per request. Clearing the thread-local here, while the
+    thread is still alive, lets the handles be released normally and stops the
+    leak. Any geometry (e.g. Map.center) touched during the request is enough
+    to trigger it, so this wraps every request.
+    """
+
+    def middleware(request):
+        try:
+            return get_response(request)
+        finally:
+            geos_io.thread_context.__dict__.clear()
+
+    return middleware
 
 
 def readonly_middleware(get_response):

--- a/umap/settings/base.py
+++ b/umap/settings/base.py
@@ -230,6 +230,7 @@ TEMPLATES = [
 # =============================================================================
 
 MIDDLEWARE = [
+    "umap.middleware.geos_thread_cleanup",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",
     "django.middleware.common.CommonMiddleware",


### PR DESCRIPTION
cf #3349
cf https://code.djangoproject.com/ticket/29878

This issue revealed when switching to ASGI, as Django will use one thread per request, but the real issue is unrelated. Real fix would be in Django, but much longer to have it released, so let's patch anyway and see if we have the bandwidth to do so.