### PR TITLE
fix: crash when tilelayer is an int

### DIFF
--- a/umap/models.py
+++ b/umap/models.py
@@ -288,6 +288,11 @@ class Map(NamedModel):
         # let's be defensive.
         if self.settings is None:
             self.settings = {}
+        # Some maps (legacy exports re-imported?) carry
+        # `tilelayer` as a bare id instead of the expected object.
+        props = self.settings.get("properties") or {}
+        if not isinstance(props.get("tilelayer", {}), dict):
+            del props["tilelayer"]
         super().save(*args, **kwargs)
 
     def move_to_trash(self):


### PR DESCRIPTION
Seems to be related to old maps (or old backups reimported?).

Also fixed in DB on OSMFR server (3 rows).

cf #3348