### PR TITLE
chore: set global.JSDOM before actually running the js tests

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,3 @@
+{
+  "file": "umap/static/umap/unittests/setup.js"
+}

--- a/umap/static/umap/js/modules/utils.js
+++ b/umap/static/umap/js/modules/utils.js
@@ -26,7 +26,6 @@ export function checkId(string) {
   return /^[A-Za-z0-9]{5}$/.test(string)
 }
 
-
 /**
  * Import DOM purify, and initialize it.
  *

--- a/umap/static/umap/unittests/schema.js
+++ b/umap/static/umap/unittests/schema.js
@@ -1,11 +1,6 @@
-// Export JSDOM to the global namespace, to be able to check for its presence
-// in the actual implementation. Avoiding monkeypatching the implementations here.
-import { JSDOM } from 'jsdom'
-global.JSDOM = JSDOM
-
+import pkg from 'chai'
 import { describe, it } from 'mocha'
 import * as Schema from '../js/modules/schema.js'
-import pkg from 'chai'
 const { assert, expect } = pkg
 
 

--- a/umap/static/umap/unittests/setup.js
+++ b/umap/static/umap/unittests/setup.js
@@ -1,0 +1,5 @@
+// Provide JSDOM in the global scope for the node-side getPurify (utils.js),
+// before any source module is evaluated. Loaded via .mocharc `file`, so it runs
+// before the spec files (and thus before schema.js builds SCHEMA at load time).
+import { JSDOM } from 'jsdom'
+global.JSDOM = JSDOM

--- a/umap/static/umap/unittests/utils.js
+++ b/umap/static/umap/unittests/utils.js
@@ -1,11 +1,6 @@
-// Export JSDOM to the global namespace, to be able to check for its presence
-// in the actual implementation. Avoiding monkeypatching the implementations here.
-import { JSDOM } from 'jsdom'
-global.JSDOM = JSDOM
-
+import pkg from 'chai'
 import { describe, it } from 'mocha'
 import * as Utils from '../js/modules/utils.js'
-import pkg from 'chai'
 const { assert, expect } = pkg
 
 describe('Utils', () => {


### PR DESCRIPTION
Setting it in the unittests files itself could not work because schema.js will call translate() at load time, and in JS modules imports are always called before the module body (so the order of the import vs the global.JSDOM affectation does not matter).