### PR TITLE
fix: do not share loader event between maps

### DIFF
--- a/umap/static/umap/js/modules/app.js
+++ b/umap/static/umap/js/modules/app.js
@@ -135,6 +135,11 @@ export default class App extends Utils.WithEvents {
     this.filters = new Filters(this, this)
     this.rules = new Rules(this, this)
 
+    this.request.on('dataloading', (event) => this.loader.start(event.detail.id))
+    this.request.on('dataload', (event) => this.loader.stop(event.detail.id))
+    this.server.on('dataloading', (event) => this.loader.start(event.detail.id))
+    this.server.on('dataload', (event) => this.loader.stop(event.detail.id))
+
     if (this.hasEditMode()) {
       this.editPanel = new EditPanel(this)
       this.fullPanel = new FullPanel(this)

--- a/umap/static/umap/js/modules/request.js
+++ b/umap/static/umap/js/modules/request.js
@@ -1,5 +1,6 @@
 import { Alert } from '../components/alerts/alert.js'
 import { translate } from './i18n.js'
+import * as Utils from './utils.js'
 
 export class RequestError extends Error {}
 
@@ -19,7 +20,7 @@ export class NOKError extends RequestError {
   }
 }
 
-class BaseRequest {
+class BaseRequest extends Utils.WithEvents {
   async _fetch(method, uri, headers, data) {
     let response
 
@@ -47,10 +48,6 @@ class BaseRequest {
 // In case of error, an alert is sent, but non 20X status are not handled
 // The consumer must check the response status by hand
 export class Request extends BaseRequest {
-  fire(name, detail) {
-    document.body.dispatchEvent(new CustomEvent(name, { detail }))
-  }
-
   async _fetch(method, uri, headers, data) {
     const id = Math.random()
     this.fire('dataloading', { id: id })
@@ -105,7 +102,7 @@ export class ServerRequest extends Request {
 
   async post(uri, headers, data) {
     const token = document.cookie.replace(
-      /(?:(?:^|.*;\s*)csrftoken\s*\=\s*([^;]*).*$)|^.*$/,
+      /(?:(?:^|.*;\s*)csrftoken\s*=\s*([^;]*).*$)|^.*$/,
       '$1'
     )
     if (token) {

--- a/umap/static/umap/js/modules/ui/loader.js
+++ b/umap/static/umap/js/modules/ui/loader.js
@@ -5,10 +5,6 @@ export default class Loader {
     this.parent = parent
     this.element = loadTemplate('<div class="umap-loader"></div>')
     this.parent.appendChild(this.element)
-    document.body.addEventListener('dataloading', (event) =>
-      this.start(event.detail.id)
-    )
-    document.body.addEventListener('dataload', (event) => this.stop(event.detail.id))
     this._counter = new Set()
   }
 


### PR DESCRIPTION
Otherwise in a map list (eg. the home page), all maps show the loader as soon as one map is loading something.