### PR TITLE
fix: be more defensive for invalid datetime

### DIFF
--- a/umap/static/umap/js/modules/filters.js
+++ b/umap/static/umap/js/modules/filters.js
@@ -1,7 +1,7 @@
-import { translate } from './i18n.js'
 import { Form } from './form/builder.js'
-import * as Utils from './utils.js'
 import { Fields } from './form/fields.js'
+import { translate } from './i18n.js'
+import * as Utils from './utils.js'
 
 const EMPTY_VALUE = translate('[empty value]')
 
@@ -672,7 +672,11 @@ Fields.FilterByDateTime = class extends Fields.FilterByDate {
   prepareForHTML(value) {
     // Value must be in local time
     if (Number.isNaN(value)) return
-    return this.toLocaleDateTime(value).toISOString().slice(0, -1)
+    try {
+      return this.toLocaleDateTime(value).toISOString().slice(0, -1)
+    } catch {
+      return undefined
+    }
   }
 }
 


### PR DESCRIPTION
This is a JS trap specificaly when using a US browser and setting French dates: month and days will be inverted when JS will parse back the string, and BAM.

We have parseNaiveDate helper to deal with this cases, but it only cares about dates, not datetimes, which is way more complex to parse. We may add a dependency for dealing with this at somepoint.