### PR TITLE
chore: do not register a new url on each hash change

### DIFF
--- a/umap/static/umap/js/modules/ui/hash.js
+++ b/umap/static/umap/js/modules/ui/hash.js
@@ -10,7 +10,7 @@ export default class Hash {
 
   update({ zoom, coordinate }) {
     const [lng, lat] = coordinate
-    window.location.hash = `#${zoom}/${lat}/${lng}`
+    history.replaceState(null, '', `#${zoom}/${lat}/${lng}`)
   }
 
   parse() {

--- a/umap/tests/integration/test_datalayer.py
+++ b/umap/tests/integration/test_datalayer.py
@@ -28,23 +28,26 @@ def test_honour_displayOnLoad_false(map, live_server, datalayer, page):
     expect(markers).to_be_visible()
 
 
-def test_should_honour_fromZoom(live_server, map, datalayer, page):
+def test_should_honour_fromZoom(live_server, map, datalayer, new_page):
     datalayer.settings.update(displayOnLoad=True, fromZoom=6)
     datalayer.save()
+    page = new_page()
     page.goto(f"{live_server.url}{map.get_absolute_url()}#5/48.55/14.68")
     markers = page.locator(".leaflet-marker-icon")
     expect(markers).to_be_hidden()
-    page.goto(f"{live_server.url}{map.get_absolute_url()}#6/48.55/14.68")
-    expect(page).to_have_url(re.compile(r".*#6/48\..+/14\..+"))
-    expect(markers).to_be_visible()
-    page.get_by_label("Zoom out").click()
-    expect(markers).to_be_hidden()
-    page.get_by_label("Zoom in").click()
-    expect(page).to_have_url(re.compile(r".*#6/48\..+/14\..+"))
-    expect(markers).to_be_visible()
-    page.get_by_label("Zoom in").click()
-    expect(page).to_have_url(re.compile(r".*#7/48\..+/14\..+"))
-    expect(markers).to_be_visible()
+    page2 = new_page()
+    page2.goto(f"{live_server.url}{map.get_absolute_url()}#6/48.55/14.68")
+    expect(page2).to_have_url(re.compile(r".*#6/48\..+/14\..+"))
+    markers2 = page2.locator(".leaflet-marker-icon")
+    expect(markers2).to_be_visible()
+    page2.get_by_label("Zoom out").click()
+    expect(markers2).to_be_hidden()
+    page2.get_by_label("Zoom in").click()
+    expect(page2).to_have_url(re.compile(r".*#6/48\..+/14\..+"))
+    expect(markers2).to_be_visible()
+    page2.get_by_label("Zoom in").click()
+    expect(page2).to_have_url(re.compile(r".*#7/48\..+/14\..+"))
+    expect(markers2).to_be_visible()
 
 
 def test_should_honour_toZoom(live_server, map, datalayer, page, new_page):


### PR DESCRIPTION
Otherwise we end up filling the browser history on each move/zoom on the map.