### PR TITLE
fix: truncate the cache file name not to hit Linux limit

### DIFF
--- a/umap/tests/integration/test_edit_datalayer.py
+++ b/umap/tests/integration/test_edit_datalayer.py
@@ -171,8 +171,9 @@ def test_can_create_new_datalayer(live_server, openmap, page, datalayer):
     expect(page.locator(".umap-is-dirty")).to_be_hidden()
 
 
-def test_can_restore_version(live_server, openmap, page, datalayer):
+def test_can_restore_version(live_server, openmap, page, datalayer, wait_for_edit_mode):
     page.goto(f"{live_server.url}{openmap.get_absolute_url()}?edit")
+    wait_for_edit_mode(page)
     marker = page.locator(".leaflet-marker-icon")
     expect(marker).to_contain_class("umap-ball-icon")
     marker.click(modifiers=["Shift"])

--- a/umap/tests/test_views.py
+++ b/umap/tests/test_views.py
@@ -330,6 +330,28 @@ async def test_proxy_sets_nosniff(
     assert response["X-Content-Type-Options"] == "nosniff"
 
 
+async def test_proxy_long_url_does_not_exceed_filename_limit(
+    async_client, proxy_cache_dir, proxy_headers, httpx_handler
+):
+    httpx_handler.handler = lambda request: httpx.Response(
+        200, content=b"OK", headers={"content-type": "text/plain"}
+    )
+    long_url = "http://example.org/?q=" + "a" * 500
+    r1 = await async_client.get(proxy_url(), {"url": long_url}, headers=proxy_headers)
+    assert r1.status_code == 200
+    assert r1["X-CACHE"] == "MISS"
+    assert b"OK" in b"".join(r1.streaming_content)
+    expected_name = f"{_cache_basename(long_url)[:240]}.cache"
+    assert len(expected_name) <= 255
+    assert (proxy_cache_dir / expected_name).exists()
+
+    # Should reuse the same cache file.
+    r2 = await async_client.get(proxy_url(), {"url": long_url}, headers=proxy_headers)
+    assert r2.status_code == 200
+    assert r2["X-CACHE"] == "HIT"
+    assert [f.name for f in proxy_cache_dir.glob("*.cache")] == [expected_name]
+
+
 @pytest.mark.django_db
 def test_login_does_not_contain_form_if_not_enabled(client, settings):
     settings.ENABLE_ACCOUNT_LOGIN = False

--- a/umap/views.py
+++ b/umap/views.py
@@ -463,7 +463,8 @@ class AjaxProxy(View):
             return HttpResponseBadRequest()
 
         cache_dir = Path(settings.AJAX_PROXY_CACHE_DIR)
-        basename = f"umap_{base64.urlsafe_b64encode(url.encode()).decode()}"
+        # Max file name length in Linux is 255 (including the extension)
+        basename = f"umap_{base64.urlsafe_b64encode(url.encode()).decode()}"[:240]
         cache_file = cache_dir / f"{basename}.cache"
         semaphore = cache_dir / f"{basename}.tmp"
 


### PR DESCRIPTION
An Overpass URL can be very long…