### PR TITLE
fix: align popup content for RTL languages

### DIFF
--- a/umap/static/umap/css/popup.css
+++ b/umap/static/umap/css/popup.css
@@ -65,6 +65,7 @@ span.popup-icon {
 
 .leaflet-popup-content-wrapper {
     border-radius: 4px;
+    text-align: start;
 }
 
 .umap-popup-content {

--- a/umap/tests/integration/test_popup.py
+++ b/umap/tests/integration/test_popup.py
@@ -73,3 +73,26 @@ def test_table_popup(live_server, map, page):
     expect(page.get_by_role("cell", name="with bold").locator("strong")).to_have_text(
         "bold"
     )
+
+
+def test_popup_alignment_in_rtl_language(live_server, map, page):
+    data = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [2.49, 48.79]},
+                "properties": {"name": "מסעדה"},
+                "id": "AzMjk",
+            },
+        ],
+    }
+    DataLayerFactory(map=map, data=data)
+    path = map.get_absolute_url().replace("/en/", "/he/")
+    page.goto(f"{live_server.url}{path}#18/48.79/2.49")
+    page.locator(".leaflet-marker-icon").click()
+
+    expect(page.locator("html")).to_have_attribute("dir", "rtl")
+    expect(page.locator(".leaflet-popup-content-wrapper")).to_have_css(
+        "text-align", "start"
+    )


### PR DESCRIPTION
Fixes #3356

Leaflet sets popup wrappers to `text-align: left`, which overrides the direction inherited from uMap's RTL document. Override that physical alignment with the logical `start` value so popup content aligns left in LTR languages and right in RTL languages.

Add a Playwright regression test that opens a Hebrew map, verifies the document is RTL, and checks that the popup uses logical start alignment.

## Tests

- `DATABASE_URL=postgis://postgres:postgres@localhost:55432/postgres uv run pytest -n 0 -vv umap/tests/integration/test_popup.py umap/tests/integration/test_view_marker.py umap/tests/integration/test_view_polygon.py umap/tests/integration/test_view_polyline.py --reruns 1 --maxfail 3` (16 passed)
- `DATABASE_URL=postgis://postgres:postgres@localhost:55432/postgres uv run pytest -n 0 -vv umap/tests/integration/test_websocket_sync.py --reruns 1 --maxfail 3` (17 passed)
- `TZ=UTC make testjs` (161 passed)
- `uv run ruff format --check --target-version=py310 umap/tests/integration/test_popup.py`
- `uv run ruff check umap/tests/integration/test_popup.py`
- `npx eslint umap/static/umap/js/`