### PR TITLE
fix: fix overlay opacity initial value

### DIFF
--- a/umap/static/umap/js/modules/app.js
+++ b/umap/static/umap/js/modules/app.js
@@ -1079,7 +1079,18 @@ export default class App extends Utils.WithEvents {
       ],
       [
         'properties.overlay.opacity',
-        { handler: 'Range', min: 0, max: 1, step: 0.1, label: translate('Opacity') },
+        {
+          handler: 'Range',
+          min: 0,
+          max: 1,
+          step: 0.1,
+          label: translate('Opacity'),
+          // Without this, the field name ("opacity") collides with the
+          // inheritable SCHEMA.opacity, so the initial value is read from
+          // app.getOption('opacity') instead of properties.overlay.opacity.
+          // TODO: remove me when schema is per-model instead of one global.
+          inheritable: false,
+        },
       ],
       ['properties.overlay.tms', { handler: 'Switch', label: translate('TMS format') }],
     ]


### PR DESCRIPTION
cf https://github.com/umap-project/umap/issues/3434

The real fix would have been to either have a per-model schema (big task) or to have an explicit link from the form field to the schema (still to big task for the moment).