### PR TITLE
fix: use sha256 instead of base64 for ajax proxy cache file names

### DIFF
--- a/umap/tests/test_views.py
+++ b/umap/tests/test_views.py
@@ -1,4 +1,4 @@
-import base64
+import hashlib
 import json
 import os
 import time
@@ -62,7 +62,7 @@ def proxy_url(ttl=300):
 
 
 def _cache_basename(url):
-    return f"umap_{base64.urlsafe_b64encode(url.encode()).decode()}"
+    return f"umap_{hashlib.sha256(url.encode()).hexdigest()}"
 
 
 async def test_valid_proxy_request(async_client, proxy_cache_dir, proxy_headers):
@@ -341,7 +341,7 @@ async def test_proxy_long_url_does_not_exceed_filename_limit(
     assert r1.status_code == 200
     assert r1["X-CACHE"] == "MISS"
     assert b"OK" in b"".join(r1.streaming_content)
-    expected_name = f"{_cache_basename(long_url)[:240]}.cache"
+    expected_name = f"{_cache_basename(long_url)}.cache"
     assert len(expected_name) <= 255
     assert (proxy_cache_dir / expected_name).exists()
 
@@ -350,6 +350,33 @@ async def test_proxy_long_url_does_not_exceed_filename_limit(
     assert r2.status_code == 200
     assert r2["X-CACHE"] == "HIT"
     assert [f.name for f in proxy_cache_dir.glob("*.cache")] == [expected_name]
+
+
+async def test_proxy_long_urls_with_common_prefix_do_not_collide(
+    async_client, proxy_cache_dir, proxy_headers, httpx_handler
+):
+    # Two distinct URLs sharing a long common prefix must map to distinct cache
+    # files. Truncating the (base64) URL to a fixed length used to make them
+    # collide, so the second URL was served the first one's cached body.
+    def handler(request):
+        marker = request.url.query.decode() if request.url.query else ""
+        return httpx.Response(
+            200, content=marker.encode(), headers={"content-type": "text/plain"}
+        )
+
+    httpx_handler.handler = handler
+
+    prefix = "http://example.org/?q=" + "a" * 300
+    r1 = await async_client.get(
+        proxy_url(), {"url": f"{prefix}FIRST"}, headers=proxy_headers
+    )
+    r2 = await async_client.get(
+        proxy_url(), {"url": f"{prefix}SECOND"}, headers=proxy_headers
+    )
+    assert b"FIRST" in b"".join(r1.streaming_content)
+    assert r2["X-CACHE"] == "MISS"
+    assert b"SECOND" in b"".join(r2.streaming_content)
+    assert len(list(proxy_cache_dir.glob("*.cache"))) == 2
 
 
 @pytest.mark.django_db

--- a/umap/views.py
+++ b/umap/views.py
@@ -1,5 +1,5 @@
 import asyncio
-import base64
+import hashlib
 import io
 import json
 import logging
@@ -457,8 +457,7 @@ class AjaxProxy(View):
             return HttpResponseBadRequest()
 
         cache_dir = Path(settings.AJAX_PROXY_CACHE_DIR)
-        # Max file name length in Linux is 255 (including the extension)
-        basename = f"umap_{base64.urlsafe_b64encode(url.encode()).decode()}"[:240]
+        basename = f"umap_{hashlib.sha256(url.encode()).hexdigest()}"
         cache_file = cache_dir / f"{basename}.cache"
         semaphore = cache_dir / f"{basename}.tmp"
 


### PR DESCRIPTION
Truncating a base64 hash may end with shared file caches between long URL with identical fisrt chars (eg. an overpass URL, or a long URL with just a query string parameter diffence at the end).