### PR TITLE
fix: export absolute iconUrl paths in .umap files for pictograms

### DIFF
--- a/umap/models.py
+++ b/umap/models.py
@@ -321,6 +321,7 @@ class Map(NamedModel):
             if include_data:
                 with datalayer.geojson.open("rb") as f:
                     layer = json.loads(f.read())
+                self._make_icon_urls_absolute(layer, request)
             if datalayer.settings:
                 datalayer.settings.pop("id", None)
                 datalayer.settings.pop("parent", None)
@@ -330,6 +331,18 @@ class Map(NamedModel):
             datalayers.append(layer)
         umapjson["layers"] = layers_tree(datalayers, keep_ids=False)
         return umapjson
+
+    @staticmethod
+    def _make_icon_urls_absolute(layer, request):
+        if not isinstance(layer, dict):
+            return
+        for feature in layer.get("features") or []:
+            props = feature.get("properties")
+            if not isinstance(props, dict):
+                continue
+            icon_url = props.get("iconUrl")
+            if icon_url and icon_url.startswith("/"):
+                props["iconUrl"] = request.build_absolute_uri(icon_url)
 
     def get_absolute_url(self):
         return reverse("map", kwargs={"slug": self.slug or "map", "map_id": self.pk})

--- a/umap/tests/test_map.py
+++ b/umap/tests/test_map.py
@@ -204,3 +204,28 @@ def test_move_to_trash(user, map):
     map.save()
     reloaded = Map.objects.get(pk=map.pk)
     assert reloaded.share_status == Map.DELETED
+
+
+def test_make_icon_urls_absolute(rf):
+    request = rf.get("/")
+    layer = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"iconUrl": "/uploads/pictogram/beach.svg"},
+            },
+            {
+                "type": "Feature",
+                "properties": {"iconUrl": "https://example.com/icon.svg"},
+            },
+            {
+                "type": "Feature",
+                "properties": {},
+            },
+        ],
+    }
+    Map._make_icon_urls_absolute(layer, request)
+    assert layer["features"][0]["properties"]["iconUrl"] == "http://testserver/uploads/pictogram/beach.svg"
+    assert layer["features"][1]["properties"]["iconUrl"] == "https://example.com/icon.svg"
+    assert "iconUrl" not in layer["features"][2]["properties"]


### PR DESCRIPTION
## What
When exporting a map to .umap format, icon URLs for pictorial markers (e.g. Osmic SVG icons) were serialized as relative paths (e.g. `/uploads/pictogram/beach.svg`), which break when the file is used outside the original uMap instance.

This fix converts relative `iconUrl` paths to absolute URLs during export using `request.build_absolute_uri()`, ensuring icons render correctly in third-party tools like Myosmatic without manual path editing.

The change is in `Map.generate_umapjson()` in `models.py` — a new `_make_icon_urls_absolute` static method iterates over every feature in the exported GeoJSON and converts any `iconUrl` starting with `/` to a fully qualified URL.

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

Fixes #3442