### PR TITLE
fix: don't overlay max/minZoom override tilelayer

### DIFF
--- a/umap/static/umap/js/modules/rendering/leaflet.js
+++ b/umap/static/umap/js/modules/rendering/leaflet.js
@@ -665,7 +665,10 @@ class TileLayerManager {
   setOverlay() {
     const spec = this.app.properties.overlay
     if (!spec?.url_template) return
-    const overlay = this.create(spec)
+    const base = this.current?.options
+    const minZoom = spec.minZoom > base?.minZoom ? spec.minZoom : base?.minZoom
+    const maxZoom = spec.maxZoom < base?.maxZoom ? spec.maxZoom : base?.maxZoom
+    const overlay = this.create({ ...spec, minZoom, maxZoom })
     try {
       this.map.addLayer(overlay)
       if (this.overlay) this.map.removeLayer(this.overlay)

--- a/umap/tests/integration/test_tilelayer.py
+++ b/umap/tests/integration/test_tilelayer.py
@@ -116,3 +116,41 @@ def test_can_have_smart_text_in_attribution(tilelayer, map, live_server, page):
     page.goto(f"{live_server.url}{map.get_absolute_url()}")
     expect(page.get_by_text("© OpenStreetMap contributors")).to_be_visible()
     expect(page.get_by_role("link", name="OpenStreetMap")).to_be_visible()
+
+
+def test_custom_tilelayer_maxzoom_is_respected(map, live_server, tilelayers, page):
+    map.settings["properties"]["tilelayer"]["maxZoom"] = 10
+    map.save()
+    page.goto(f"{live_server.url}{map.get_absolute_url()}")
+    page.wait_for_selector(".leaflet-tile-pane img")
+    max_zoom = page.evaluate("() => U.MAP.mapProxy.map.getMaxZoom()")
+    assert max_zoom == 10
+
+
+def test_overlay_default_maxzoom_does_not_widen_base(
+    map, live_server, tilelayers, page
+):
+    map.settings["properties"]["tilelayer"]["maxZoom"] = 10
+    map.settings["properties"]["overlay"] = {
+        "url_template": "https://a.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png",
+        "attribution": "overlay",
+    }
+    map.save()
+    page.goto(f"{live_server.url}{map.get_absolute_url()}")
+    page.wait_for_selector(".leaflet-tile-pane img")
+    max_zoom = page.evaluate("() => U.MAP.mapProxy.map.getMaxZoom()")
+    assert max_zoom == 10
+
+
+def test_overlay_higher_maxzoom_is_clamped_to_base(map, live_server, tilelayers, page):
+    map.settings["properties"]["tilelayer"]["maxZoom"] = 10
+    map.settings["properties"]["overlay"] = {
+        "url_template": "https://a.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png",
+        "attribution": "overlay",
+        "maxZoom": 20,
+    }
+    map.save()
+    page.goto(f"{live_server.url}{map.get_absolute_url()}")
+    page.wait_for_selector(".leaflet-tile-pane img")
+    max_zoom = page.evaluate("() => U.MAP.mapProxy.map.getMaxZoom()")
+    assert max_zoom == 10


### PR DESCRIPTION
Overlay is an "extra" background layer, so it must not extend the normal tilelayer min/maxZoom (or we'll have blank tiles).

cf #3434 

(More tests to convert to OL, but… who knows when the 4.x really lands ? :p )